### PR TITLE
Dockerfile enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ MAINTAINER Datical <liquibase@datical.com>
 RUN apt-get update \
   && apt-get install -yq --no-install-recommends \
       libmariadb-java \
-      libpostgresql-jdbc-java 
+      libpostgresql-jdbc-java \
+  && apt-get autoclean \
+  && apt-get clean \
+  && rm -rf /var/*/apt/*
 # /usr/share/java/mariadb-java-client.jar
 # /usr/share/java/postgresql.jar
 
@@ -19,16 +22,14 @@ WORKDIR /liquibase
 USER liquibase
 
 # Latest Liquibase Release Version
-ENV LIQUIBASE_VERSION 3.8.6
+ARG LIQUIBASE_VERSION=3.8.6
 
 # Download, install, clean up
 RUN set -x \
-  && curl -L https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz -o liquibase-core-${LIQUIBASE_VERSION}-bin.tar.gz \
-  && tar -xzf liquibase-core-${LIQUIBASE_VERSION}-bin.tar.gz \
-  && rm liquibase-core-${LIQUIBASE_VERSION}-bin.tar.gz 
+  && curl -L https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz | tar -xzf -
 
 # Set liquibase to executable
-RUN chmod 777 /liquibase
+RUN chmod 755 /liquibase
 
 ENTRYPOINT ["/liquibase/liquibase"]
 CMD ["--help"]


### PR DESCRIPTION
Update apt-get command to perform cleanup, shrinks existing image by about 20MB

Use ARG instead of ENV for LIQUIBASE_VERSION.  This enables you to pass the Liquibase
  version at image build time and create tagged builds easily.  Also avoids setting
  an extra env variable during docker run.  Example tagged build command:
docker build . --build-arg LIQUIBASE_VERSION=3.8.5 -t liquibase/docker:3.8.5

Simplify download logic and avoid the intermediate file

Use chmod safely (755 vs 777)