### PR TITLE
add sqlite support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN curl -o /liquibase/lib/db2.jar https://repo1.maven.org/maven2/com/ibm/db2/jc
 RUN curl -o /liquibase/lib/snowflake.jar https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.12.3/snowflake-jdbc-3.12.3.jar
 RUN curl -o /liquibase/lib/sybase.jar https://repo1.maven.org/maven2/net/sf/squirrel-sql/plugins/sybase/3.5.0/sybase-3.5.0.jar
 RUN curl -o /liquibase/lib/firebird.jar https://repo1.maven.org/maven2/net/sf/squirrel-sql/plugins/firebird/3.5.0/firebird-3.5.0.jar
+RUN curl -o /liquibase/lib/sqlite.jar https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.31.1/sqlite-jdbc-3.31.1.jar
 
 ENTRYPOINT ["/liquibase/liquibase"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ This is the official repository for [Liquibase Command-line](https://download.li
 
 `docker run --rm -v <PATH TO CHANGELOG DIR>:/liquibase/changelog liquibase/liquibase --url="jdbc:jtds:sybase://<IP OR HOSTNAME>:/<DATABASE>" --changeLogFile=/liquibase/changelog/<CHANGELOG NAME ie: "changelog.xml"> --username=<USERNAME> --password=<PASSWORD> generateChangeLog`
 
+## SQLite
 
+`docker run --rm -v <PATH TO DB FILE>:/liquibase/<DB FILE NAME>.db -v <PATH TO CHANGELOG DIR>:/liquibase/changelog liquibase/liquibase --url="jdbc:sqlite:/liquibase/<DB FILE NAME>.db" --changeLogFile=/liquibase/changelog/<CHANGELOG NAME ie: "changelog.xml"> generateChangeLog`
 
 ## Using Oracle or any other Host Located JDBC Libraries
 


### PR DESCRIPTION
This PR adds SQLite support to the docker image. This is especially useful for local testing without spinning up a full database (e.g. applying the schema on a DB used during unit tests).

The `*.db` file must be mounted in `/liquibase/` to be writable.