### PR TITLE
Fix issue 33. Set correct permissions for docker-entrypoint.sh

### DIFF
--- a/3.10.x/Dockerfile
+++ b/3.10.x/Dockerfile
@@ -82,6 +82,7 @@ ARG MYSQL_SHA256=f93c6d717fff1bdc8941f0feba66ac13692e58dc382ca4b543cabbdb150d8bf
 RUN wget -O /liquibase/lib/mysql.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.19/mysql-connector-java-8.0.19.jar \
 	&& echo "$MYSQL_SHA256  /liquibase/lib/mysql.jar" | sha256sum -c - 
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY --chown=liquibase:liquibase docker-entrypoint.sh /usr/local/bin/
+RUN chmod 0755 /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,7 @@ ARG MYSQL_SHA256=f93c6d717fff1bdc8941f0feba66ac13692e58dc382ca4b543cabbdb150d8bf
 RUN wget -O /liquibase/lib/mysql.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.19/mysql-connector-java-8.0.19.jar \
 	&& echo "$MYSQL_SHA256  /liquibase/lib/mysql.jar" | sha256sum -c - 
 
-COPY docker-entrypoint.sh /usr/local/bin/
+COPY --chown=liquibase:liquibase docker-entrypoint.sh /usr/local/bin/
+RUN chmod 0755 /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["--help"]


### PR DESCRIPTION
This should fix the problem with the latest Docker build reported in https://github.com/liquibase/docker/issues/33 