### PR TITLE
Updating the snowflake-jdbc driver to 3.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,8 @@ RUN wget --no-verbose -O wget -O /liquibase/lib/db2.jar https://repo1.maven.org/
 	&& echo "$DB2_SHA1 /liquibase/lib/db2.jar" | sha1sum -c - 
 
 ARG SNOWFLAKE_SHA1=ea2280f496bbd8e31c628edca2cfff6ee0aa4c24
-RUN wget --no-verbose -O /liquibase/lib/snowflake.jar https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.12.3/snowflake-jdbc-3.12.3.jar \
-	&& wget --no-verbose -O wget -O /liquibase/lib/snowflake.jar.asc https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.12.3/snowflake-jdbc-3.12.3.jar.asc \
+RUN wget --no-verbose -O /liquibase/lib/snowflake.jar https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.13.1/snowflake-jdbc-3.13.1.jar \
+	&& wget --no-verbose -O wget -O /liquibase/lib/snowflake.jar.asc https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.13.1/snowflake-jdbc-3.13.1.jar.asc \
     && gpg --auto-key-locate keyserver --keyserver ha.pool.sks-keyservers.net --keyserver-options auto-key-retrieve --verify /liquibase/lib/snowflake.jar.asc /liquibase/lib/snowflake.jar \
 	&& echo "$SNOWFLAKE_SHA1 /liquibase/lib/snowflake.jar" | sha1sum -c - 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN wget --no-verbose -O wget -O /liquibase/lib/db2.jar https://repo1.maven.org/
     && gpg --auto-key-locate keyserver --keyserver ha.pool.sks-keyservers.net --keyserver-options auto-key-retrieve --verify /liquibase/lib/db2.jar.asc /liquibase/lib/db2.jar \
 	&& echo "$DB2_SHA1 /liquibase/lib/db2.jar" | sha1sum -c - 
 
-ARG SNOWFLAKE_SHA1=ea2280f496bbd8e31c628edca2cfff6ee0aa4c24
+ARG SNOWFLAKE_SHA1=33d436d13eacdd34d78d5089fae29e31a3e3abb5
 RUN wget --no-verbose -O /liquibase/lib/snowflake.jar https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.13.1/snowflake-jdbc-3.13.1.jar \
 	&& wget --no-verbose -O wget -O /liquibase/lib/snowflake.jar.asc https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.13.1/snowflake-jdbc-3.13.1.jar.asc \
     && gpg --auto-key-locate keyserver --keyserver ha.pool.sks-keyservers.net --keyserver-options auto-key-retrieve --verify /liquibase/lib/snowflake.jar.asc /liquibase/lib/snowflake.jar \


### PR DESCRIPTION
> The older version of the snowflake-jdbc-3.12.3 driver version introduced the` Illegal reflective access warning `mentioned in this issue# https://github.com/snowflakedb/snowflake-jdbc/issues/202. The updated snowflake-jdbc-3.13.1.jar version fixing the issue as tested in our environment.

> Test job ran with the default liquibase latest container getting the error : 

![Screen Shot 2021-03-22 at 5 29 24 PM](https://user-images.githubusercontent.com/81197641/112074841-6987cd80-8b34-11eb-9804-a13e8ae8b1d6.png)

> The same test job ran with the local liquibase container with an updated snowflake-jdbc-3.13.1.jar

![Screen Shot 2021-03-22 at 5 32 41 PM](https://user-images.githubusercontent.com/81197641/112074919-9c31c600-8b34-11eb-8083-02907b13901c.png)

> Local docker file

![Screen Shot 2021-03-22 at 5 35 00 PM](https://user-images.githubusercontent.com/81197641/112075054-ef0b7d80-8b34-11eb-905e-deaac7a57902.png)

