### PR TITLE
bump version to v4.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ RUN ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh \
 USER liquibase
 
 # Latest Liquibase Release Version
-ARG LIQUIBASE_VERSION=4.3.2
+ARG LIQUIBASE_VERSION=4.3.4
 
 # Download, verify, extract
-ARG LB_SHA256=b1cfd6e0dfa97756e12e2c902ea9b48f6a3f46f893f222b3059703d06443aaa1
+ARG LB_SHA256=b56938016d85d6ffb90bb1a3f48e9ce0955f6900d711531d3e868a69f6bb3a01
 RUN set -x \
   && wget -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" \
   && echo "$LB_SHA256  liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,10 @@ RUN set -x \
   && rm liquibase-${LIQUIBASE_VERSION}.tar.gz
 
 # Download JDBC libraries, verify via GPG and checksum
-ARG PG_SHA1=a0a9c1d43c7727eeaf1b729477891185d3c71751
-RUN wget --no-verbose -O /liquibase/lib/postgresql.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.18/postgresql-42.2.18.jar \
-	&& wget --no-verbose -O /liquibase/lib/postgresql.jar.asc https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.18/postgresql-42.2.18.jar.asc \
+ARG PG_VERSION=42.2.19
+ARG PG_SHA1=85cb20fe8151b6d90900d5ae5cfe0ad7c3e8f921
+RUN wget --no-verbose -O /liquibase/lib/postgresql.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/${PG_VERSION}/postgresql-${PG_VERSION}.jar \
+	&& wget --no-verbose -O /liquibase/lib/postgresql.jar.asc https://repo1.maven.org/maven2/org/postgresql/postgresql/${PG_VERSION}/postgresql-${PG_VERSION}.jar.asc \
     && gpg --auto-key-locate keyserver --keyserver ha.pool.sks-keyservers.net --keyserver-options auto-key-retrieve --verify /liquibase/lib/postgresql.jar.asc /liquibase/lib/postgresql.jar \
 	&& echo "$PG_SHA1  /liquibase/lib/postgresql.jar" | sha1sum -c - 
 


### PR DESCRIPTION
Bumps to the latest version v4.3.4.

local build succeeded
```
...
Removing intermediate container 7125a0462515
 ---> 2e140c5ac46d
Step 36/37 : ENTRYPOINT ["/liquibase/docker-entrypoint.sh"]
 ---> Running in b8b103b8ed97
Removing intermediate container b8b103b8ed97
 ---> e5849330814b
Step 37/37 : CMD ["--help"]
 ---> Running in 1856e1e870fd
Removing intermediate container 1856e1e870fd
 ---> 20848375ae7c
Successfully built 20848375ae7c
Successfully tagged liquibase:latest

```