### PR TITLE
Feature/lpm drivers on init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN rm lpm.zip
 RUN export LIQUIBASE_HOME=/liquibase
 
 # Install Drivers
-RUN lpm add postgresql mssql mariadb db2 snowflake sybase firebird sqlite oracle mysql --global
+RUN lpm add postgresql mssql mariadb db2 snowflake sybase firebird sqlite oracle --global
 
 COPY --chown=liquibase:liquibase docker-entrypoint.sh /liquibase/
 COPY --chown=liquibase:liquibase liquibase.docker.properties /liquibase/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:11-jre-slim-buster
 # Install GNUPG for package vefification and WGET for file download
 RUN apt-get update \
     && apt-get -yqq install krb5-user libpam-krb5 \
-    && apt-get -y install gnupg wget \
+    && apt-get -y install gnupg wget unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Add the liquibase user and step in the directory
@@ -17,7 +17,8 @@ WORKDIR /liquibase
 #Symbolic link will be broken until later
 RUN ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh \
   && ln -s /liquibase/docker-entrypoint.sh /docker-entrypoint.sh \
-  && ln -s /liquibase/liquibase /usr/local/bin/liquibase
+  && ln -s /liquibase/liquibase /usr/local/bin/liquibase \
+  && ln -s /liquibase/bin/lpm /usr/local/bin/lpm
 
 # Change to the liquibase user
 USER liquibase
@@ -33,77 +34,15 @@ RUN set -x \
   && tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz \
   && rm liquibase-${LIQUIBASE_VERSION}.tar.gz
 
-# Download JDBC libraries, verify via GPG and checksum
-ARG PG_VERSION=42.2.23
-ARG PG_SHA1=9cb217a3d5b640567ed7c6e8c11f389613c81c4d
-RUN wget --no-verbose -O /liquibase/lib/postgresql.jar "https://repo1.maven.org/maven2/org/postgresql/postgresql/${PG_VERSION}/postgresql-${PG_VERSION}.jar" \
-	&& wget --no-verbose -O /liquibase/lib/postgresql.jar.asc https://repo1.maven.org/maven2/org/postgresql/postgresql/${PG_VERSION}/postgresql-${PG_VERSION}.jar.asc \
-    && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/postgresql.jar.asc /liquibase/lib/postgresql.jar \
-	&& echo "$PG_SHA1  /liquibase/lib/postgresql.jar" | sha1sum -c - 
+# Download and Install lpm \
+RUN mkdir /liquibase/bin
+RUN wget -q -O lpm.zip https://github.com/mcred/liquibase-package-manager/releases/download/v0.1.0/lpm-0.1.0-linux.zip
+RUN unzip lpm.zip -d bin/
+RUN rm lpm.zip
+RUN export LIQUIBASE_HOME=/liquibase
 
-ARG MSSQL_SHA1=7af72fb8f832634f7717f971a85ba199729b7eaa
-RUN wget --no-verbose -O /liquibase/lib/mssql.jar https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/9.2.1.jre11/mssql-jdbc-9.2.1.jre11.jar \
-	&& wget --no-verbose -O /liquibase/lib/mssql.jar.asc https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/9.2.1.jre11/mssql-jdbc-9.2.1.jre11.jar.asc \
-    && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/mssql.jar.asc /liquibase/lib/mssql.jar \
-	&& echo "$MSSQL_SHA1 /liquibase/lib/mssql.jar" | sha1sum -c - 
-
-ARG MARIADB_SHA1=4a2edc05bd882ad19371d2615c2635dccf8d74f0
-RUN wget --no-verbose -O /liquibase/lib/mariadb.jar https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/2.7.3/mariadb-java-client-2.7.3.jar \
-	&& wget --no-verbose -O wget -O /liquibase/lib/mariadb.jar.asc https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/2.7.3/mariadb-java-client-2.7.3.jar.asc \
-    && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/mariadb.jar.asc /liquibase/lib/mariadb.jar \
-	&& echo "$MARIADB_SHA1 /liquibase/lib/mariadb.jar" | sha1sum -c - 
-
-ARG H2_SHA1=f7533fe7cb8e99c87a43d325a77b4b678ad9031a
-RUN wget --no-verbose -O /liquibase/lib/h2.jar https://repo1.maven.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200.jar \
-	&& wget --no-verbose -O wget -O /liquibase/lib/h2.jar.asc https://repo1.maven.org/maven2/com/h2database/h2/1.4.200/h2-1.4.200.jar.asc \
-    && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/h2.jar.asc /liquibase/lib/h2.jar \
-	&& echo "$H2_SHA1 /liquibase/lib/h2.jar" | sha1sum -c - 
-
-ARG DB2_VERSION=11.5.6.0
-ARG DB2_SHA1=34704e47398c467e256fd181c75ffb85d1fac9a9
-RUN wget --no-verbose -O /liquibase/lib/db2.jar "https://repo1.maven.org/maven2/com/ibm/db2/jcc/${DB2_VERSION}/jcc-${DB2_VERSION}.jar" \
-	&& wget --no-verbose -O wget -O /liquibase/lib/db2.jar.asc "https://repo1.maven.org/maven2/com/ibm/db2/jcc/${DB2_VERSION}/jcc-${DB2_VERSION}.jar.asc" \
-    && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/db2.jar.asc /liquibase/lib/db2.jar \
-	&& echo "$DB2_SHA1 /liquibase/lib/db2.jar" | sha1sum -c -
-
-ARG SNOWFLAKE_VERSION=3.13.6
-ARG SNOWFLAKE_SHA1=056053012ed5c92d516c04f06675c8d825160a54
-RUN wget --no-verbose -O /liquibase/lib/snowflake.jar "https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/${SNOWFLAKE_VERSION}/snowflake-jdbc-${SNOWFLAKE_VERSION}.jar" \
-	&& wget --no-verbose -O wget -O /liquibase/lib/snowflake.jar.asc "https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/${SNOWFLAKE_VERSION}/snowflake-jdbc-${SNOWFLAKE_VERSION}.jar.asc" \
-    && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/snowflake.jar.asc /liquibase/lib/snowflake.jar \
-	&& echo "$SNOWFLAKE_SHA1 /liquibase/lib/snowflake.jar" | sha1sum -c -
-
-ARG SYBASE_SHA1=4a939221fe3023da2ddfc63ecf902a0f970d4d70
-RUN wget --no-verbose -O /liquibase/lib/sybase.jar https://repo1.maven.org/maven2/net/sf/squirrel-sql/plugins/sybase/3.5.0/sybase-3.5.0.jar \
-	&& wget --no-verbose -O /liquibase/lib/sybase.jar.asc https://repo1.maven.org/maven2/net/sf/squirrel-sql/plugins/sybase/3.5.0/sybase-3.5.0.jar.asc \
-    && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/sybase.jar.asc /liquibase/lib/sybase.jar \
-	&& echo "$SYBASE_SHA1 /liquibase/lib/sybase.jar" | sha1sum -c - 
-
-ARG FIREBIRD_SHA1=40386c1fb29971ab96451a2d0c0d6aafaedea0c0
-RUN wget --no-verbose -O /liquibase/lib/firebird.jar https://repo1.maven.org/maven2/net/sf/squirrel-sql/plugins/firebird/3.5.0/firebird-3.5.0.jar \
-	&& wget --no-verbose -O wget -O /liquibase/lib/firebird.jar.asc https://repo1.maven.org/maven2/net/sf/squirrel-sql/plugins/firebird/3.5.0/firebird-3.5.0.jar.asc \
-    && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/firebird.jar.asc /liquibase/lib/firebird.jar \
-	&& echo "$FIREBIRD_SHA1 /liquibase/lib/firebird.jar" | sha1sum -c - 
-
-ARG SQLITE_VERSION=3.36.0.1
-ARG SQLITE_SHA1=7bd89ad11392210f8e86282004519b36d53cb9ee
-RUN wget --no-verbose -O /liquibase/lib/sqlite.jar "https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/${SQLITE_VERSION}/sqlite-jdbc-${SQLITE_VERSION}.jar" \
-	&& wget --no-verbose -O /liquibase/lib/sqlite.jar.asc "https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/${SQLITE_VERSION}/sqlite-jdbc-${SQLITE_VERSION}.jar.asc" \
-    && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/sqlite.jar.asc /liquibase/lib/sqlite.jar \
-	&& echo "$SQLITE_SHA1 /liquibase/lib/sqlite.jar" | sha1sum -c - 
-
-ARG ORACLE_SHA1=967c0b1a2d5b1435324de34a9b8018d294f8f47b
-RUN wget --no-verbose -O /liquibase/lib/ojdbc8.jar https://repo1.maven.org/maven2/com/oracle/ojdbc/ojdbc8/19.3.0.0/ojdbc8-19.3.0.0.jar \
-	&& wget --no-verbose -O /liquibase/lib/ojdbc8.jar.asc https://repo1.maven.org/maven2/com/oracle/ojdbc/ojdbc8/19.3.0.0/ojdbc8-19.3.0.0.jar.asc \
-    && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/ojdbc8.jar.asc /liquibase/lib/ojdbc8.jar \
-	&& echo "$ORACLE_SHA1 /liquibase/lib/ojdbc8.jar" | sha1sum -c - 
-
-ARG MYSQL_VERSION=8.0.26
-ARG MYSQL_SHA256=3e1dddd5fdbcd78a552a8fc915fcb804e4f7f83a873355972a3c97a22556f62c
-RUN wget --no-verbose -O /liquibase/lib/mysql.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_VERSION}/mysql-connector-java-${MYSQL_VERSION}.jar \
-	&& wget --no-verbose -O /liquibase/lib/mysql.jar.asc https://repo1.maven.org/maven2/mysql/mysql-connector-java/${MYSQL_VERSION}/mysql-connector-java-${MYSQL_VERSION}.jar.asc \
-    && gpg --auto-key-locate keyserver --keyserver keyserver.ubuntu.com --keyserver-options auto-key-retrieve --verify /liquibase/lib/mysql.jar.asc /liquibase/lib/mysql.jar \
-	&& echo "$MYSQL_SHA256  /liquibase/lib/mysql.jar" | sha256sum -c - 
+# Install Drivers
+RUN lpm add postgresql mssql mariadb db2 snowflake sybase firebird sqlite oracle mysql --global
 
 COPY --chown=liquibase:liquibase docker-entrypoint.sh /liquibase/
 COPY --chown=liquibase:liquibase liquibase.docker.properties /liquibase/

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
 
 # Download and Install lpm \
 RUN mkdir /liquibase/bin
-RUN wget -q -O lpm.zip https://github.com/mcred/liquibase-package-manager/releases/download/v0.1.0/lpm-0.1.0-linux.zip
+RUN wget -q -O lpm.zip https://github.com/liquibase/liquibase-package-manager/releases/download/v0.1.0/lpm-0.1.0-linux.zip
 RUN unzip lpm.zip -d bin/
 RUN rm lpm.zip
 RUN export LIQUIBASE_HOME=/liquibase

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-gt
 ## Official Liquibase Docker images
 
 [![Docker Auto Build](https://img.shields.io/docker/cloud/automated/liquibase/liquibase)][docker]

--- a/README.md
+++ b/README.md
@@ -69,11 +69,31 @@ If you have a local `c:\projects\my-project\src\main\resources\liquibase.propert
 
 ## Drivers and Extensions
 
-The Liquibase docker container ships with drivers for many popular databases. If your driver is not included or if you have an extension, you can mount a local directory containing the jars to `/liquibase/classpath` and add the jars to your `classpath` setting.   
+The Liquibase docker container ships with drivers for many popular databases. If your driver is not included or if you have an extension, you can mount a local directory containing the jars to `/liquibase/classpath` and add the jars to your `classpath` setting. 
 
 #### Example
 
 If you have a local `c:\projects\my-project\lib\my-driver.jar` file, `docker runliquibase/liquibase --rm -v c:\projects\my-project\src\main\resources:/liquibase/changelog -v c:\projects\my-project\lib:/liquibase/classpath --classpath=/liquibase/changelog:/liquibase/classpath/my-driver.jar update`
+
+### Notice for MySQL Users
+Due to licensing restrictions for the MySQL driver, this container does not ship with the MySQL driver installed. Two options exist for loading this driver: 1. Create a new container from the `liquibase/liquibase` image. 2. Load this driver during runtime via an environment variable. 
+
+#### New Container Example
+Dockerfile
+```dockerfile
+FROM liquibase/liquibase
+
+RUN lpm add mysql --global
+```
+Build
+```shell
+docker build . -t liquibase/liquibase-mysql
+```
+
+#### Runtime Example
+```shell
+docker run -e INSTALL_MYSQL=true liquibase/liquibase update
+```
 
 ## Complete Examples
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+if [[ "INSTALL_MYSQL" ]]; then
+  lpm add mysql --global
+fi
+
 if type "$1" > /dev/null 2>&1; then
   ## First argument is an actual OS command. Run it
   exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [[ "INSTALL_MYSQL" ]]; then
+if [[ "$INSTALL_MYSQL" ]]; then
   lpm add mysql --global
 fi
 

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,0 +1,3 @@
+FROM liquibase/liquibase
+
+RUN lpm add mysql --global


### PR DESCRIPTION
Based on GPL restrictions, we can not distribute the mysql driver with the docker container. To work around this, the way drivers are loaded has changed.

* All drivers are now loaded using lpm (liquibase package manager)
* The mysql driver is loaded during run time based on an environment variable `INSTALL_MYSQL`

Example:
```bash
docker run -e INSTALL_MYSQL=true liquibase/liquibase update
Checksum verified. Installing mysql-connector-java-8.0.25.jar to /liquibase/lib/
mysql-connector-java-8.0.25.jar successfully installed in classpath.
####################################################
##   _     _             _ _                      ##
##  | |   (_)           (_) |                     ##
##  | |    _  __ _ _   _ _| |__   __ _ ___  ___   ##
##  | |   | |/ _` | | | | | '_ \ / _` / __|/ _ \  ##
##  | |___| | (_| | |_| | | |_) | (_| \__ \  __/  ##
##  \_____/_|\__, |\__,_|_|_.__/ \__,_|___/\___|  ##
##              | |                               ##
##              |_|                               ##
##                                                ## 
##  Get documentation at docs.liquibase.com       ##
##  Get certified courses at learn.liquibase.com  ## 
##  Free schema change activity reports at        ##
##      https://hub.liquibase.com                 ##
##                                                ##
####################################################
Starting Liquibase at 15:04:17 (version 4.4.2 #39 built at 2021-07-22 18:11+0000)
Liquibase Version: 4.4.2
Liquibase Community 4.4.2 by Datical
Error parsing command line: Invalid argument '--changelog-file': missing required argument
```