### PR TITLE
Updated release automation

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,105 @@
+name: Release Extension (v2)
+on:
+  repository_dispatch:
+    types: [liquibase-release]
+  workflow_dispatch:
+    inputs:
+      liquibaseVersion:
+        description: 'Liquibase Version'
+        required: true
+      extensionVersion:
+        description: 'Docker Version (Defaults to Liquibase Version)'
+        required: false
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      liquibaseVersion: ${{ steps.collect-data.outputs.liquibaseVersion }}
+      extensionVersion: ${{ steps.collect-data.outputs.extensionVersion }}
+    steps:
+      - name: Collect Data
+        id: collect-data
+        uses: actions/github-script@v4
+        with:
+          script: |
+            if (context.payload.client_payload) {
+                core.setOutput("liquibaseVersion", context.payload.client_payload.liquibaseVersion);
+                core.setOutput("extensionVersion", context.payload.client_payload.liquibaseVersion);
+            } else if (context.payload.inputs) {
+                core.setOutput("liquibaseVersion", context.payload.inputs.liquibaseVersion);
+                core.setOutput("extensionVersion", context.payload.inputs.extensionVersion || context.payload.inputs.liquibaseVersion);
+            } else {
+              core.setFailed('Unknown event type')
+            }
+
+      - run: |
+          echo "Saw Liquibase version ${{ steps.collect-data.outputs.liquibaseVersion }}"
+          echo "Saw Extension version ${{ steps.collect-data.outputs.extensionVersion }}"
+
+  build:
+    name: "Build and Test"
+    runs-on: ubuntu-latest
+    needs: setup
+    outputs:
+      releaseSha: ${{ steps.get-release-sha.outputs.releaseSha }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Configure git user
+        run: |
+          git config user.name "liquibot"
+          git config user.email "liquibot@liquibase.org"
+
+      - name: Update Dockerfile and commit changes
+        run: |
+          LIQUIBASE_SHA=`curl -LsS https://github.com/liquibase/liquibase/releases/download/v${{ needs.setup.outputs.liquibaseVersion }}/liquibase-${{ needs.setup.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }'`
+          sed -i 's/^ARG LIQUIBASE_VERSION=.*/ARG LIQUIBASE_VERSION='"${{ needs.setup.outputs.liquibaseVersion }}"'/' ${{ github.workspace }}/Dockerfile
+          sed -i 's/^ARG LB_SHA256=.*/ARG LB_SHA256='"$LIQUIBASE_SHA"'/' ${{ github.workspace }}/Dockerfile
+
+      - name: Update pom.xml with release versions and commit changes
+        run: |
+          if git diff-index --cached --quiet HEAD --
+          then
+            echo "Nothing new to commit"
+          else
+            git add Dockerfile
+            git commit -m "Liquibase Version Bumped to ${{ needs.setup.outputs.extensionVersion }}"
+          fi
+          git tag -a -m "Version Bumped to ${{ needs.setup.outputs.extensionVersion }}" v${{ needs.setup.outputs.extensionVersion }}
+          git push "https://liquibot:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.ref }} --follow-tags --tags
+
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+
+      - name: Get release SHA
+        id: get-release-sha
+        run: echo ::set-output name=releaseSha::$(git rev-parse HEAD)
+
+  draft-release:
+    needs: [ setup, build, integration-tests ]
+    name: Draft Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          target_commitish: ${{ needs.build.outputs.releaseSha }}
+          name: v${{ needs.setup.outputs.extensionVersion }}
+          tag_name: v${{ needs.setup.outputs.extensionVersion }}
+          draft: true
+          body: Support for Liquibase ${{ needs.setup.outputs.liquibaseVersion }}.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -35,51 +35,6 @@ jobs:
         with:
           repo-token: ${{ secrets.BOT_TOKEN }}
 
-      # automation steps for liquibase-core
-      - name: Get CORE_TARGET_VERSION from PR
-        if: ${{ steps.metadata.outputs.dependency-name == 'org.liquibase:liquibase-core' }}   
-        run: |
-          echo 'CORE_TARGET_VERSION<<EOF' >> $GITHUB_ENV
-          gh pr view "$PR_URL" | grep "Bump liquibase-core" | awk '{ print $7 }' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.BOT_TOKEN}} 
-          
-      - name: Compute sha256 for liquibase-$CORE_TARGET_VERSION.tar.gz 
-        if: ${{ steps.metadata.outputs.dependency-name == 'org.liquibase:liquibase-core' }}  
-        run: |
-          echo 'CORE_TARGET_SHA<<EOF' >> $GITHUB_ENV
-          curl -LsS https://github.com/liquibase/liquibase/releases/download/v$CORE_TARGET_VERSION/liquibase-$CORE_TARGET_VERSION.tar.gz | sha256sum | awk '{ print $1 }' >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-          
-      - name: edit core Dockerfile
-        if: ${{ steps.metadata.outputs.dependency-name == 'org.liquibase:liquibase-core' }}  
-        run: |
-          sed -i 's/^ARG LIQUIBASE_VERSION=.*/ARG LIQUIBASE_VERSION='"$CORE_TARGET_VERSION"'/' ${{ github.workspace }}/Dockerfile
-          sed -i 's/^ARG LB_SHA256=.*/ARG LB_SHA256='"$CORE_TARGET_SHA"'/' ${{ github.workspace }}/Dockerfile
-
-      - name: push Dockerfile edit back to PR
-        if: ${{ steps.metadata.outputs.dependency-name == 'org.liquibase:liquibase-core' }}
-        run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
-          git add .
-          git commit -m "auto-update liquibase-core Dockerfile"
-          git push -u origin HEAD:"$GITHUB_HEAD_REF"
-        env:
-          GITHUB_HEAD_REF: ${{github.head_ref}}
-
-      - name: Bump version and push tag
-        if: ${{ steps.metadata.outputs.dependency-name == 'org.liquibase:liquibase-core' }} 
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v5.6
-        with:
-          github_token: ${{ secrets.BOT_TOKEN }}
-          create_annotated_tag: true
-          custom_tag : ${{env.CORE_TARGET_VERSION}}
-
-
       # automation steps for liquibase-snowflake extension
       - name: Get SNOWFLAKE_TARGET_VERSION from PR
         if: ${{ steps.metadata.outputs.dependency-name == 'org.liquibase.ext:liquibase-snowflake' }} 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN rm lpm.zip
 RUN export LIQUIBASE_HOME=/liquibase
 
 # Install Drivers
-RUN lpm add postgresql mssql mariadb db2 snowflake sybase firebird sqlite oracle --global
+RUN lpm add snowflake --global
 RUN ls -alh /liquibase/lib
 
 COPY --chown=liquibase:liquibase docker-entrypoint.sh /liquibase/

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.liquibase</groupId>
-            <artifactId>liquibase-core</artifactId>
-            <version>4.5.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.liquibase.ext</groupId>
             <artifactId>liquibase-snowflake</artifactId>
             <version>4.4.3</version>


### PR DESCRIPTION
## Description

Instead of relying on dependabot, this automation is passed the liquibase version to use and makes the needed changes directly and without going through a PR.

This action can be triggered manually, but will mainly be called from another action in liquibase/liquibase as part of the release process there.

