### PR TITLE
added lpm command for liquibase-snowflake extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,7 @@ RUN export LIQUIBASE_HOME=/liquibase
 
 # Install Drivers
 RUN lpm update
-RUN lpm add snowflake --global
-RUN lpm add liquibase-snowflake --global
+RUN lpm add snowflake liquibase-snowflake --global
 RUN ls -alh /liquibase/lib
 
 COPY --chown=liquibase:liquibase docker-entrypoint.sh /liquibase/

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN export LIQUIBASE_HOME=/liquibase
 # Install Drivers
 RUN lpm update
 RUN lpm add snowflake --global
+RUN lpm add liquibase-snowflake --global
 RUN ls -alh /liquibase/lib
 
 COPY --chown=liquibase:liquibase docker-entrypoint.sh /liquibase/


### PR DESCRIPTION
Needed to add `RUN lpm add liquibase-snowflake --global` command in order to put the liquibase-snowflake extension into the docker image. 

Without this extension the docker images is not ready to be used with Snowflake databases.