### PR TITLE
Output driver info with `liquibase --version` instead of `ls -l lib`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN export LIQUIBASE_HOME=/liquibase
 # Install Drivers
 RUN lpm update
 RUN lpm add snowflake liquibase-snowflake --global
-RUN ls -alh /liquibase/lib
+RUN /liquibase/liquibase --version
 
 COPY --chown=liquibase:liquibase docker-entrypoint.sh /liquibase/
 COPY --chown=liquibase:liquibase liquibase.docker.properties /liquibase/


### PR DESCRIPTION
## Description

Liquibase 4.11 removes the shipped drivers out of /liquibase/lib. This PR changes the call to list the driver versions with a call to `liquibase --version` which includes that information.