### PR TITLE
Update Dockerfile to use Temurin Java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-focal
 
 # Install GNUPG for package vefification and WGET for file download
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jre-focal
+FROM eclipse-temurin:17-jre-focal
 
 # Install GNUPG for package vefification and WGET for file download
 RUN apt-get update \


### PR DESCRIPTION
OpenJDK has been deprecated:
https://hub.docker.com/_/openjdk

DEPRECATION NOTICE
This image is officially deprecated and all users are recommended to find and use suitable replacements ASAP. Some examples of other Official Image alternatives (listed in alphabetical order with no intentional or implied preference):

amazoncorretto
eclipse-temurin
ibm-semeru-runtimes
ibmjava
sapmachine
See docker-library/openjdk#505 for more information.

The only tags which will continue to receive updates beyond July 2022 will be Early Access builds (which are sourced from jdk.java.net), as those are not published/supported by any of the above projects.