### PR TITLE
fixed some markdown-formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ Each specific release has an associated tag
 - `4.1.0`
 - `3.10.3`
 
-## Changelog Files
+## Changelog File
 
 The docker image has a /liquibase/changelog volume in which the directory containing the root of your changelog tree can be mounted. Your `--changeLogFile` argument should list paths relative to this.
 
 The /liquibase/changelog volume can also be used for commands that write output, such as `generateChangeLog`. Note that in this case (where liquibase should write a new file) you need to specify the absolute path to the changelog, i.e. prefix the path with `/liquibase/changelog/<PATH TO CHANGELOG FILE>`.
 
-### Example
+### Changelog File Example
 
 If you have a local `c:\projects\my-project\src\main\resources\com\example\changelogs\root.changelog.xml` file, you would run `docker run --rm -v c:\projects\my-project\src\main\resources:/liquibase/changelog liquibase/liquibase --changeLogFile=changelog/com/example/changelogs/root.changelog.xml update`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Official Liquibase Docker images
+# Official Liquibase Docker images
 
 [![Docker Auto Build](https://img.shields.io/docker/cloud/automated/liquibase/liquibase)][docker]
 
@@ -8,19 +8,19 @@ This is the official repository for [Liquibase](https://download.liquibase.org/)
 
 ## BREAKING CHANGE
 
-Support for Snowflake database has been moved from the external extension liquibase-snowflake into the main Liquibase artifact. This means that Snowflake is now included in the main docker image. If you are using the snowflake extension remove it from your lib directory or however you are including it in your project. If you are using the Docker image, use the main v4.12+ as there will no longer be a snowflake separate docker image produced.  The latest separate Snowflake image will be v4.11. You need to update your reference to either latest to use the main one that includes Snowflake or the version tag you prefer.  https://github.com/liquibase/liquibase/pull/2841
+Support for Snowflake database has been moved from the external extension liquibase-snowflake into the main Liquibase artifact. This means that Snowflake is now included in the main docker image. If you are using the snowflake extension remove it from your lib directory or however you are including it in your project. If you are using the Docker image, use the main v4.12+ as there will no longer be a snowflake separate docker image produced.  The latest separate Snowflake image will be v4.11. You need to update your reference to either latest to use the main one that includes Snowflake or the version tag you prefer. <https://github.com/liquibase/liquibase/pull/2841>
 
 ## Supported Tags
 
 The following tags are officially supported:
 
-#### Overall Most Recent Build
+### Overall Most Recent Build
 
 The latest tag will be kept up to date with the most advanced Liquibase release.
 
--	`latest`
+- `latest`
 
-#### Latest Major/Minor Builds
+### Latest Major/Minor Builds
 
 These tags are kept up to date with the most recent patch release of each X.Y stream
 
@@ -43,7 +43,7 @@ These tags are kept up to date with the most recent patch release of each X.Y st
 - `4.1`
 - `3.10`
 
-#### Specific Releases
+### Specific Releases
 
 Each specific release has an associated tag
 
@@ -88,7 +88,7 @@ The docker image has a /liquibase/changelog volume in which the directory contai
 
 The /liquibase/changelog volume can also be used for commands that write output, such as `generateChangeLog`. Note that in this case (where liquibase should write a new file) you need to specify the absolute path to the changelog, i.e. prefix the path with `/liquibase/changelog/<PATH TO CHANGELOG FILE>`.
 
-#### Example
+### Example
 
 If you have a local `c:\projects\my-project\src\main\resources\com\example\changelogs\root.changelog.xml` file, you would run `docker run --rm -v c:\projects\my-project\src\main\resources:/liquibase/changelog liquibase/liquibase --changeLogFile=changelog/com/example/changelogs/root.changelog.xml update`
 
@@ -98,69 +98,75 @@ To generate a new changelog file at this location, run `docker run --rm -v c:\pr
 
 If you would like to use a "default file" to specify arguments rather than passing them on the command line, include it in your changelog volume mount and reference it.
 
-If specifying a custom liquibase.properties file, make sure you include `classpath=/liquibase/changelog` so Liquibase will continue to look for your changelog files there.   
+If specifying a custom liquibase.properties file, make sure you include `classpath=/liquibase/changelog` so Liquibase will continue to look for your changelog files there.
 
-#### Example
+### Configuration File Example
 
 If you have a local `c:\projects\my-project\src\main\resources\liquibase.properties` file, you would run `docker run --rm -v c:\projects\my-project\src\main\resources:/liquibase/changelog liquibase/liquibase --defaultsFile=liquibase.properties update`
 
 ## Drivers and Extensions
 
-The Liquibase docker container ships with drivers for many popular databases. If your driver is not included or if you have an extension, you can mount a local directory containing the jars to `/liquibase/classpath` and add the jars to your `classpath` setting. 
+The Liquibase docker container ships with drivers for many popular databases. If your driver is not included or if you have an extension, you can mount a local directory containing the jars to `/liquibase/classpath` and add the jars to your `classpath` setting.
 
-#### Example
+### Driver and Extensions Example
 
 If you have a local `c:\projects\my-project\lib\my-driver.jar` file, `docker run --rm -v c:\projects\my-project\src\main\resources:/liquibase/changelog -v c:\projects\my-project\lib:/liquibase/classpath liquibase/liquibase --classpath=/liquibase/changelog:/liquibase/classpath/my-driver.jar update`
 
 ### Notice for MySQL Users
-Due to licensing restrictions for the MySQL driver, this container does not ship with the MySQL driver installed. Two options exist for loading this driver: 1. Create a new container from the `liquibase/liquibase` image. 2. Load this driver during runtime via an environment variable. 
 
-#### New Container Example
+Due to licensing restrictions for the MySQL driver, this container does not ship with the MySQL driver installed. Two options exist for loading this driver: 1. Create a new container from the `liquibase/liquibase` image. 2. Load this driver during runtime via an environment variable.
+
+### New Container Example
+
 Dockerfile
+
 ```dockerfile
 FROM liquibase/liquibase
 
 RUN lpm add mysql --global
 ```
+
 Build
+
 ```shell
 docker build . -t liquibase/liquibase-mysql
 ```
 
-#### Runtime Example
+### Runtime Example
+
 ```shell
 docker run -e INSTALL_MYSQL=true liquibase/liquibase update
 ```
 
 ## Complete Examples
 
-#### Specify everything via arguments 
+### Specify everything via arguments
 
 `docker run --rm -v <PATH TO CHANGELOG DIR>:/liquibase/changelog liquibase/liquibase --url="jdbc:sqlserver://<IP OR HOSTNAME>:1433;database=<DATABASE>;" --changeLogFile=com/example/changelog.xml --username=<USERNAME> --password=<PASSWORD> --liquibaseProLicenseKey="<PASTE LB PRO LICENSE KEY HERE>" update`
 
 Using with [Liquibase Pro Environment Variables](https://docs.liquibase.com/concepts/basic/liquibase-environment-variables.html) example:
-` docker run --env LIQUIBASE_COMMAND_USERNAME --env LIQUIBASE_COMMAND_PASSWORD --env LIQUIBASE_COMMAND_URL --env LIQUIBASE_PRO_LICENSE_KEY --env LIQUIBASE_COMMAND_CHANGELOG_FILE --rm -v <PATH TO CHANGELOG DIR>/changelogs:/liquibase/changelog liquibase/liquibase --log-level=info update`
+`docker run --env LIQUIBASE_COMMAND_USERNAME --env LIQUIBASE_COMMAND_PASSWORD --env LIQUIBASE_COMMAND_URL --env LIQUIBASE_PRO_LICENSE_KEY --env LIQUIBASE_COMMAND_CHANGELOG_FILE --rm -v <PATH TO CHANGELOG DIR>/changelogs:/liquibase/changelog liquibase/liquibase --log-level=info update`
 
-
-#### Using a properties file
+### Using a properties file
 
 *liquibase.docker.properties file:*
-```
+
+```dockerfile
 classpath: /liquibase/changelog
 url: jdbc:postgresql://<IP OR HOSTNAME>:5432/<DATABASE>?currentSchema=<SCHEMA NAME>
 changeLogFile: changelog.xml
 username: <USERNAME>
 password: <PASSWORD>
-liquibaseProLicenseKey=<PASTE LB PRO LICENSE KEY HERE> 
+liquibaseProLicenseKey=<PASTE LB PRO LICENSE KEY HERE>
 ```
 
 *CLI:*
-`docker run --rm -v <PATH TO CHANGELOG DIR>:/liquibase/changelog liquibase/liquibase --defaultsFile=liquibase.docker.properties update`  
 
-or `docker run --rm -v <PATH TO CHANGELOG DIR>:/liquibase/changelog liquibase/liquibase --defaultsFile=liquibase.docker.properties --changeLogFile=changelog.xml generateChangeLog` (the argument `--changeLogFile` wins against the defaultsFile)
+`docker run --rm -v <PATH TO CHANGELOG DIR>:/liquibase/changelog liquibase/liquibase --defaultsFile=liquibase.docker.properties update`
+or
+`docker run --rm -v <PATH TO CHANGELOG DIR>:/liquibase/changelog liquibase/liquibase --defaultsFile=liquibase.docker.properties --changeLogFile=changelog.xml generateChangeLog` (the argument `--changeLogFile` wins against the defaultsFile)
 
-
-#### Example JDBC Urls:
+### Example JDBC Urls
 
 - MS SQL Server: `jdbc:sqlserver://<IP OR HOSTNAME>:1433;database=<DATABASE>`
 - PostgreSQL: `jdbc:postgresql://<IP OR HOSTNAME>:5432/<DATABASE>?currentSchema=<SCHEMA NAME>`
@@ -173,6 +179,6 @@ or `docker run --rm -v <PATH TO CHANGELOG DIR>:/liquibase/changelog liquibase/li
 
 Note: If the database IP refers to a locally running docker container then one needs to specify host networking like `docker run --network=host -rm -v ...`
 
-#### Adding Native Executors
+### Adding Native Executors
 
 The recommended path for adding native executors/binaries such as Oracle SQL*Plus, Microsoft SQLCMD, Postgres PSQL, or the AWS CLI is to extend the liquibase/liquibase Dockerfile.  Examples are provided in the [Examples](/examples) Directory.


### PR DESCRIPTION
Fixed some markdown-formatting-issues inside the README and adjusted the headline-levels.

This does mostly comply with the rules defined here: <https://github.com/markdownlint/markdownlint>
The only rule which doesn't apply is `MD013 Line length`. With a maximal default line length of 80 characters.

```output
README.md:7:81 MD013/line-length Line length [Expected: 80; Actual: 88]
README.md:11:81 MD013/line-length Line length [Expected: 80; Actual: 674]
README.md:87:81 MD013/line-length Line length [Expected: 80; Actual: 200]
README.md:89:81 MD013/line-length Line length [Expected: 80; Actual: 305]
README.md:93:81 MD013/line-length Line length [Expected: 80; Actual: 304]
README.md:95:81 MD013/line-length Line length [Expected: 80; Actual: 244]
README.md:99:81 MD013/line-length Line length [Expected: 80; Actual: 168]
README.md:101:81 MD013/line-length Line length [Expected: 80; Actual: 171]
README.md:105:81 MD013/line-length Line length [Expected: 80; Actual: 251]
README.md:109:81 MD013/line-length Line length [Expected: 80; Actual: 261]
README.md:113:81 MD013/line-length Line length [Expected: 80; Actual: 298]
README.md:117:81 MD013/line-length Line length [Expected: 80; Actual: 284]
README.md:145:81 MD013/line-length Line length [Expected: 80; Actual: 305]
README.md:147:81 MD013/line-length Line length [Expected: 80; Actual: 137]
README.md:148:81 MD013/line-length Line length [Expected: 80; Actual: 285]
README.md:165:81 MD013/line-length Line length [Expected: 80; Actual: 135]
README.md:167:81 MD013/line-length Line length [Expected: 80; Actual: 239]
README.md:172:81 MD013/line-length Line length [Expected: 80; Actual: 94]
README.md:180:81 MD013/line-length Line length [Expected: 80; Actual: 155]
README.md:184:81 MD013/line-length Line length [Expected: 80; Actual: 242]
```