### PR TITLE
fixes #140: allow to run liquibase history command

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,8 +5,8 @@ if [[ "$INSTALL_MYSQL" ]]; then
   lpm add mysql --global
 fi
 
-if type "$1" > /dev/null 2>&1; then
-  ## First argument is an actual OS command. Run it
+if [[ "$1" != "history" ]] && type "$1" > /dev/null 2>&1; then
+  ## First argument is an actual OS command (except if the command is history as it is a liquibase command). Run it
   exec "$@"
 else
   if [[ "$*" == *--defaultsFile* ]] || [[ "$*" == *--defaults-file* ]] || [[ "$*" == *--version* ]]; then


### PR DESCRIPTION
Hi, 

This PR allows to override default entry point behavior.
If first argument is "history" then it should not be considered as a system command but as history liquibase command.

**Tests :**

- No argument : 

```
./docker-entrypoint.sh
Could not find defaults file /liquibase/liquibase.docker.properties
####################################################
##   _     _             _ _                      ##
##  | |   (_)           (_) |                     ##
##  | |    _  __ _ _   _ _| |__   __ _ ___  ___   ##
##  | |   | |/ _` | | | | | '_ \ / _` / __|/ _ \  ##
##  | |___| | (_| | |_| | | |_) | (_| \__ \  __/  ##
##  \_____/_|\__, |\__,_|_|_.__/ \__,_|___/\___|  ##
##              | |                               ##
....
```

- ls argument

```
./docker-entrypoint.sh ls
Dockerfile                      LICENSE                         README.md                       docker-entrypoint.sh            examples                        liquibase.docker.properties     pom.xml
```

- history argument
```
./docker-entrypoint.sh history --help
Could not find defaults file /liquibase/liquibase.docker.properties
List all deployed changesets and their deployment ID

Usage: liquibase history [OPTIONS]

      --changelog-file=PARAM
                         The root changelog
                         (liquibase.command.changelogFile OR liquibase.command.
                           history.changelogFile)
                         (LIQUIBASE_COMMAND_CHANGELOG_FILE OR
                           LIQUIBASE_COMMAND_HISTORY_CHANGELOG_FILE)
                         [deprecated: --changelogFile]
```
