### PR TITLE
optimize dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,31 @@
 FROM eclipse-temurin:17-jre-jammy
 
-# Install GNUPG for package vefification and WGET for file download
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get -yqq install krb5-user libpam-krb5 \
-    && apt-get -y install gnupg wget unzip \
-    && rm -rf /var/lib/apt/lists/*
+# Install GNUPG for package verification and WGET for file download
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get -yqq install krb5-user libpam-krb5 --no-install-recommends && \
+    apt-get -y install gnupg wget unzip --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
 
 # Add the liquibase user and step in the directory
-RUN addgroup --gid 1001 liquibase
-RUN adduser --disabled-password --uid 1001 --ingroup liquibase liquibase
+RUN addgroup --gid 1001 liquibase && \
+    adduser --disabled-password --uid 1001 --ingroup liquibase liquibase
 
 # Make /liquibase directory and change owner to liquibase
 RUN mkdir /liquibase && chown liquibase /liquibase
 WORKDIR /liquibase
 
-#Symbolic link will be broken until later
-RUN ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh \
-  && ln -s /liquibase/docker-entrypoint.sh /docker-entrypoint.sh \
-  && ln -s /liquibase/liquibase /usr/local/bin/liquibase \
-  && ln -s /liquibase/bin/lpm /usr/local/bin/lpm
+# Symbolic link will be broken until later
+RUN ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
+    ln -s /liquibase/docker-entrypoint.sh /docker-entrypoint.sh && \
+    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \
+    ln -s /liquibase/bin/lpm /usr/local/bin/lpm
 
 # Change to the liquibase user
 USER liquibase
+
+# Set LIQUIBASE_HOME environment variable
+ENV LIQUIBASE_HOME=/liquibase
 
 # Latest Liquibase Release Version
 ARG LIQUIBASE_VERSION=4.21.1
@@ -30,22 +33,21 @@ ARG LPM_VERSION=0.2.0
 
 # Download, verify, extract
 ARG LB_SHA256=c04542865e5ece8b7b1ee9bd6beaefc5315e350620288d6ac1a2d32c3b1f7d8b
-RUN set -x \
-  && wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" \
-  && echo "$LB_SHA256  liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - \
-  && tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz \
-  && rm liquibase-${LIQUIBASE_VERSION}.tar.gz
+RUN set -x && \
+    wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" && \
+    echo "$LB_SHA256  liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - && \
+    tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz && \
+    rm liquibase-${LIQUIBASE_VERSION}.tar.gz
 
-# Download and Install lpm \
-RUN mkdir /liquibase/bin
-RUN wget -q -O lpm.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${LPM_VERSION}/lpm-${LPM_VERSION}-linux.zip"
-RUN unzip lpm.zip -d bin/
-RUN rm lpm.zip
-RUN export LIQUIBASE_HOME=/liquibase
+# Download and Install lpm
+RUN mkdir /liquibase/bin && \
+    wget -q -O lpm.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${LPM_VERSION}/lpm-${LPM_VERSION}-linux.zip" && \
+    unzip lpm.zip -d bin/ && \
+    rm lpm.zip
 
 # Install Drivers
-RUN lpm update
-RUN /liquibase/liquibase --version
+RUN lpm update && \
+    /liquibase/liquibase --version
 
 COPY --chown=liquibase:liquibase docker-entrypoint.sh /liquibase/
 COPY --chown=liquibase:liquibase liquibase.docker.properties /liquibase/


### PR DESCRIPTION
1. Combine RUN commands where possible to reduce the number of layers created in the image. 
2. Use && to chain commands for better readability.
3. Include --no-install-recommends option in apt-get install to minimize the image size. 
4. Remove unnecessary RUN export LIQUIBASE_HOME=/liquibase, as environment variables set in a RUN command don't persist to other steps or the final image.