### PR TITLE
Adds /liquibase/lib as a volume mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,11 @@ RUN lpm update && \
 COPY --chown=liquibase:liquibase docker-entrypoint.sh /liquibase/
 COPY --chown=liquibase:liquibase liquibase.docker.properties /liquibase/
 
+## This is not used for anything beyond an alternative location for "/liquibase/changelog", but remains for backwards compatibility
 VOLUME /liquibase/classpath
+
 VOLUME /liquibase/changelog
+VOLUME /liquibase/lib
 
 ENTRYPOINT ["/liquibase/docker-entrypoint.sh"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To generate a new changelog file at this location, run `docker run --rm -v c:\pr
 
 If you would like to use a "default file" to specify arguments rather than passing them on the command line, include it in your changelog volume mount and reference it.
 
-If specifying a custom liquibase.properties file, make sure you include `classpath=/liquibase/changelog` so Liquibase will continue to look for your changelog files there.
+If specifying a custom liquibase.properties file, make sure you include `searchPath=/liquibase/changelog` so Liquibase will continue to look for your changelog files there.
 
 ### Configuration File Example
 
@@ -118,11 +118,11 @@ If you have a local `c:\projects\my-project\src\main\resources\liquibase.propert
 
 ## Drivers and Extensions
 
-The Liquibase docker container ships with drivers for many popular databases. If your driver is not included or if you have an extension, you can mount a local directory containing the jars to `/liquibase/classpath` and add the jars to your `classpath` setting.
+The Liquibase docker container ships with drivers for many popular databases. If your driver is not included or if you have an extension, you can mount a local directory containing the jars to `/liquibase/lib`.
 
 ### Driver and Extensions Example
 
-If you have a local `c:\projects\my-project\lib\my-driver.jar` file, `docker run --rm -v c:\projects\my-project\src\main\resources:/liquibase/changelog -v c:\projects\my-project\lib:/liquibase/classpath liquibase/liquibase --classpath=/liquibase/changelog:/liquibase/classpath/my-driver.jar update`
+If you have a local `c:\projects\my-project\lib\my-driver.jar` file, `docker run --rm -v c:\projects\my-project\src\main\resources:/liquibase/changelog -v c:\projects\my-project\lib:/liquibase/lib liquibase/liquibase update`
 
 ### Notice for MySQL Users
 
@@ -164,7 +164,7 @@ Using with [Liquibase Pro Environment Variables](https://docs.liquibase.com/conc
 *liquibase.docker.properties file:*
 
 ```dockerfile
-classpath: /liquibase/changelog
+searchPath: /liquibase/changelog
 url: jdbc:postgresql://<IP OR HOSTNAME>:5432/<DATABASE>?currentSchema=<SCHEMA NAME>
 changeLogFile: changelog.xml
 username: <USERNAME>

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,10 +11,10 @@ if [[ "$1" != "history" ]] && type "$1" > /dev/null 2>&1; then
 else
   if [[ "$*" == *--defaultsFile* ]] || [[ "$*" == *--defaults-file* ]] || [[ "$*" == *--version* ]]; then
     ## Just run as-is
-    liquibase "$@"
+    /liquibase/liquibase "$@"
   else
     ## Include standard defaultsFile
-    liquibase "--defaultsFile=/liquibase/liquibase.docker.properties" "$@"
+    /liquibase/liquibase "--defaultsFile=/liquibase/liquibase.docker.properties" "$@"
   fi
 fi
 


### PR DESCRIPTION
## Description

To use extensions (and drivers), the jars have to be in the java classpath when liquibase first starts, and the only place it ever looks is `internal/lib`, `lib`, and `./liquibase_libs` regardless of what the "classpath" setting is.

This PR adds a specific mount point for `lib` to make it more obvious that they go there and updates the readme to use that mount point. It also replaces other uses of the deprecated "classpath" setting in favor of "searchPath" in the docs.

## Considerations

I thought about changing workspace in Dockerfile to be `/liquibase/changelog` which would allow users to have a `liquibase_libs` subdirectory in their project directory which gets mounted to `/liquibase/changelog` and then those "local" jars would be used as well. I ended up not changing that, since I though that might be a breaking change if people are setting their searchPath relative to the `/liquibase` workspace it currently has.

But, I left the change in `docker-entrypoint.sh` that makes liquibase have an absolute path, so users can at least override the working directory if they want and everything will still work for them.

We can consider changing the working directory in a separate PR if we'd like