### PR TITLE
Revert volume for 4.21.1 re-release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,6 @@ COPY --chown=liquibase:liquibase liquibase.docker.properties /liquibase/
 VOLUME /liquibase/classpath
 
 VOLUME /liquibase/changelog
-VOLUME /liquibase/lib
 
 ENTRYPOINT ["/liquibase/docker-entrypoint.sh"]
 CMD ["--help"]


### PR DESCRIPTION
The introduced `VOLUME /liquibase/lib` breaks how lpm installs installation and will end up breaking how all deployed workflows using the docker container and lpm work. This is a temporary fix for the 4.21.1 re-release until we can fix this issue properly for the 4.23.0 release. 