### PR TITLE
refactor release workflow to use matrix single job

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,17 +11,16 @@ on:
         description: "Container Version (Defaults to Liquibase Version)"
         required: false
 
-env:
-  IMAGE_NAME: liquibase/liquibase
-
 jobs:
-  setup:
-    name: Setup
+  setup-update-draft-build:
+    name: Setup, Update, Draft Release, Build and Push
     runs-on: ubuntu-latest
-    outputs:
-      liquibaseVersion: ${{ steps.collect-data.outputs.liquibaseVersion }}
-      extensionVersion: ${{ steps.collect-data.outputs.extensionVersion }}
-      minorVersion: ${{ steps.collect-data.outputs.minorVersion }}
+    strategy:
+      matrix:
+        image: [ 
+          {dockerfile: Dockerfile, name: liquibase/liquibase},
+          {dockerfile: Dockerfile.slim, name: liquibase/liquibase-slim}
+          ]
     steps:
       - name: Collect Data
         id: collect-data
@@ -47,83 +46,63 @@ jobs:
             } else {
               core.setFailed('Unknown event type')
             }
-
+      
       - run: |
           echo "Saw Liquibase version ${{ steps.collect-data.outputs.liquibaseVersion }}"
           echo "Saw Extension version ${{ steps.collect-data.outputs.extensionVersion }}"
-
-  update:
-    name: "Update Files"
-    runs-on: ubuntu-latest
-    needs: setup
-    outputs:
-      releaseSha: ${{ steps.get-release-sha.outputs.releaseSha }}
-    steps:
+      
       - uses: actions/checkout@v3
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
-
+          
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: "8"
           distribution: "adopt"
-
+          
       - name: Configure git user
         run: |
           git config user.name "liquibot"
           git config user.email "liquibot@liquibase.org"
-
+          
       - name: Update Dockerfile and commit changes
         run: |
-          LIQUIBASE_SHA=`curl -LsS https://github.com/liquibase/liquibase/releases/download/v${{ needs.setup.outputs.liquibaseVersion }}/liquibase-${{ needs.setup.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }'`
-          sed -i 's/^ARG LIQUIBASE_VERSION=.*/ARG LIQUIBASE_VERSION='"${{ needs.setup.outputs.liquibaseVersion }}"'/' ${{ github.workspace }}/Dockerfile
-          sed -i 's/^ARG LB_SHA256=.*/ARG LB_SHA256='"$LIQUIBASE_SHA"'/' ${{ github.workspace }}/Dockerfile
-
-          git add Dockerfile
+          LIQUIBASE_SHA=`curl -LsS https://github.com/liquibase/liquibase/releases/download/v${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }'`
+          sed -i 's/^ARG LIQUIBASE_VERSION=.*/ARG LIQUIBASE_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' ${{ github.workspace }}/${{ matrix.image.dockerfile }}
+          sed -i 's/^ARG LB_SHA256=.*/ARG LB_SHA256='"$LIQUIBASE_SHA"'/' ${{ github.workspace }}/${{ matrix.image.dockerfile }}
+          git add ${{ matrix.image.dockerfile }}
           if git diff-index --cached --quiet HEAD --
           then
             echo "Nothing new to commit"
           else
-            git commit -m "Liquibase Version Bumped to ${{ needs.setup.outputs.extensionVersion }}"
+            git commit -m "Liquibase Version Bumped to ${{ steps.collect-data.outputs.extensionVersion }} for ${{ matrix.image.name }}"
           fi
-          git tag -a -m "Version Bumped to ${{ needs.setup.outputs.extensionVersion }}" v${{ needs.setup.outputs.extensionVersion }}
+          git tag -fa -m "Version Bumped to ${{ steps.collect-data.outputs.extensionVersion }}" v${{ steps.collect-data.outputs.extensionVersion }}
           git push "https://liquibot:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.ref }} --follow-tags --tags
-
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-
+      
       - name: Get release SHA
         id: get-release-sha
         run: echo ::set-output name=releaseSha::$(git rev-parse HEAD)
-
-  draft-release:
-    needs: [setup, update]
-    name: Draft Release
-    runs-on: ubuntu-latest
-    steps:
+      
       - uses: actions/checkout@v3
-
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          target_commitish: ${{ needs.update.outputs.releaseSha }}
-          name: v${{ needs.setup.outputs.extensionVersion }}
-          tag_name: v${{ needs.setup.outputs.extensionVersion }}
+          target_commitish: ${{ steps.get-release-sha.outputs.releaseSha }}
+          name: v${{ steps.collect-data.outputs.extensionVersion }}
+          tag_name: v${{ steps.collect-data.outputs.extensionVersion }}
           draft: true
-          body: Support for Liquibase ${{ needs.setup.outputs.liquibaseVersion }}.
+          body: Support for Liquibase ${{ steps.collect-data.outputs.liquibaseVersion }}.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  build-and-push:
-    needs: [setup, update, draft-release]
-    runs-on: ubuntu-latest
-    name: Build and Push
-    steps:
+      
       - uses: actions/checkout@v3 # Checkout the SHA of the updated Dockerfile from the setup step
         with:
-          ref: ${{ needs.update.outputs.releaseSha }}
+          ref: ${{ steps.get-release-sha.outputs.releaseSha }}
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - uses: docker/login-action@v2
@@ -136,4 +115,4 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ env.IMAGE_NAME }}:latest,${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.extensionVersion }},${{ env.IMAGE_NAME }}:${{ needs.setup.outputs.minorVersion }}
+          tags: ${{ matrix.image.name }}:latest,${{ matrix.image.name }}:${{ steps.collect-data.outputs.extensionVersion }},${{ matrix.image.name }}:${{ steps.collect-data.outputs.minorVersion }}


### PR DESCRIPTION
release job was failing after #203 due to matrix outputs only being available per-job.  This PR refactors the docker setup, update, draft release, push into a single job.