### PR TITLE
Bump Alpine image and make sure to update packages #228

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # Use multi-stage build
-FROM alpine:3.17.3 as builder
+FROM alpine:3.18.2 as builder
 
 ARG TARGETARCH
 ARG LIQUIBASE_VERSION=4.23.0
@@ -28,10 +28,11 @@ RUN mkdir /liquibase/bin && \
     rm lpm.zip
 
 # Final Image
-FROM alpine:3.17.3
+FROM alpine:3.18.2
 
 # Install smaller JRE, if available and acceptable
-RUN apk add --no-cache openjdk17-jre-headless bash
+RUN apk --no-cache update && apk --no-cache upgrade && \
+    apk add --no-cache openjdk17-jre-headless bash
 
 # Add the liquibase user and step in the directory
 RUN addgroup --gid 1001 liquibase && \


### PR DESCRIPTION
This PR solves issues in #228

Here is scan result:
```
liquibase:latest (alpine 3.18.2)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

2023-07-06T07:37:37.564+0100    INFO    Table result includes only package filenames. Use '--format json' option to get the full path to the package file.

Java (jar)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

┌────────────────────────────┬────────────────┬──────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│          Library           │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                           Title                           │
├────────────────────────────┼────────────────┼──────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ com.h2database:h2 (h2.jar) │ CVE-2022-45868 │ HIGH     │ 2.1.214           │               │ The web-based admin console in H2 Database Engine through │
│                            │                │          │                   │               │ 2.1.214 can ...                                           │
│                            │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-45868                │
└────────────────────────────┴────────────────┴──────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
```

No system packages reported as vulnerable.