### PR TITLE
DAT-14654       DevOps :: Make Liquibase Docker Container a First Class Citizen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ WORKDIR /liquibase
 RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" && \
     echo "$LB_SHA256  liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - && \
     tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz && \
-    rm liquibase-${LIQUIBASE_VERSION}.tar.gz && \
-    liquibase --version
+    rm liquibase-${LIQUIBASE_VERSION}.tar.gz
 
 # Download and Install lpm
 RUN mkdir bin && \
@@ -26,9 +25,8 @@ RUN mkdir bin && \
       "arm64")  DOWNLOAD_ARCH="-arm64"  ;; \
     esac &&  wget -v -O lpm.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${LPM_VERSION}/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" && \
     unzip lpm.zip -d bin/ && \
-    rm lpm.zip && \
-    lpm help
-
+    rm lpm.zip
+    
 # Production Stage
 FROM eclipse-temurin:17-jre-jammy as production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ ARG LB_SHA256=b9667d97a0ba425547aa9fe66bafeccf4ef3b821e91ae732ec684d0eaf2fd7f5
 
 # Install necessary dependencies
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get -yqq install krb5-user libpam-krb5 gnupg wget unzip --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
@@ -17,7 +16,8 @@ WORKDIR /liquibase
 RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" && \
     echo "$LB_SHA256  liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - && \
     tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz && \
-    rm liquibase-${LIQUIBASE_VERSION}.tar.gz
+    rm liquibase-${LIQUIBASE_VERSION}.tar.gz && \
+    liquibase --version
 
 # Download and Install lpm
 RUN mkdir bin && \
@@ -26,7 +26,8 @@ RUN mkdir bin && \
       "arm64")  DOWNLOAD_ARCH="-arm64"  ;; \
     esac &&  wget -v -O lpm.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${LPM_VERSION}/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" && \
     unzip lpm.zip -d bin/ && \
-    rm lpm.zip
+    rm lpm.zip && \
+    lpm help
 
 # Production Stage
 FROM eclipse-temurin:17-jre-jammy as production

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,9 +2,9 @@
 FROM alpine:3.18.2 as builder
 
 ARG TARGETARCH
-ARG LIQUIBASE_VERSION=4.23.0
+ARG LIQUIBASE_VERSION=4.23.1
 ARG LPM_VERSION=0.2.3
-ARG LB_SHA256=988b8734da3f2f987646fa533748d9b7aae2f889741fd6922f86ae3a321ea635
+ARG LB_SHA256=b9667d97a0ba425547aa9fe66bafeccf4ef3b821e91ae732ec684d0eaf2fd7f5
 
 # Install tools for downloading and verifying packages
 RUN apk add --no-cache wget unzip gnupg
@@ -16,7 +16,8 @@ RUN set -x && \
     wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" && \
     echo "$LB_SHA256  liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - && \
     tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz && \
-    rm liquibase-${LIQUIBASE_VERSION}.tar.gz
+    rm liquibase-${LIQUIBASE_VERSION}.tar.gz && \
+    liquibase --version
 
 # Download and Install lpm
 RUN mkdir /liquibase/bin && \
@@ -25,7 +26,8 @@ RUN mkdir /liquibase/bin && \
       "arm64")  DOWNLOAD_ARCH="-arm64"  ;; \
     esac &&  wget -v -O lpm.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${LPM_VERSION}/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" && \
     unzip lpm.zip -d bin/ && \
-    rm lpm.zip
+    rm lpm.zip && \
+    lpm help
 
 # Final Image
 FROM alpine:3.18.2

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -16,8 +16,7 @@ RUN set -x && \
     wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" && \
     echo "$LB_SHA256  liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - && \
     tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz && \
-    rm liquibase-${LIQUIBASE_VERSION}.tar.gz && \
-    liquibase --version
+    rm liquibase-${LIQUIBASE_VERSION}.tar.gz
 
 # Download and Install lpm
 RUN mkdir /liquibase/bin && \
@@ -26,8 +25,7 @@ RUN mkdir /liquibase/bin && \
       "arm64")  DOWNLOAD_ARCH="-arm64"  ;; \
     esac &&  wget -v -O lpm.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${LPM_VERSION}/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" && \
     unzip lpm.zip -d bin/ && \
-    rm lpm.zip && \
-    lpm help
+    rm lpm.zip
 
 # Final Image
 FROM alpine:3.18.2

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,10 +11,10 @@ if [[ "$1" != "history" ]] && type "$1" > /dev/null 2>&1; then
 else
   if [[ "$*" == *--defaultsFile* ]] || [[ "$*" == *--defaults-file* ]] || [[ "$*" == *--version* ]]; then
     ## Just run as-is
-    /liquibase/liquibase "$@"
+    exec /liquibase/liquibase "$@"
   else
     ## Include standard defaultsFile
-    /liquibase/liquibase "--defaultsFile=/liquibase/liquibase.docker.properties" "$@"
+    exec /liquibase/liquibase "--defaultsFile=/liquibase/liquibase.docker.properties" "$@"
   fi
 fi
 


### PR DESCRIPTION
chore(Dockerfile): update LIQUIBASE_VERSION to 4.23.1 and LPM_VERSION to 0.2.3 for alpine image
chore(Dockerfile): remove unnecessary apt-get upgrade command in base image
chore(Dockerfile): add liquibase and lpm version checks after installation in both base and alpine images
chore(docker-entrypoint.sh): use 'exec' to run liquibase command for better process management