### PR TITLE
chore(create-release.yml): add step to build and push Docker image to…

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -110,6 +110,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           
+      - name: Build and Push Docker Image - Docker Hub
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          no-cache: true
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ matrix.image.name }}:latest${{ matrix.image.suffix }},${{ matrix.image.name }}:${{ steps.collect-data.outputs.extensionVersion }}${{ matrix.image.suffix }},${{ matrix.image.name }}:${{ steps.collect-data.outputs.minorVersion }}${{ matrix.image.suffix }}
+  
       - name: Login to ECR Registry
         uses: docker/login-action@v2
         env:


### PR DESCRIPTION
… Docker Hub

The previous version of the workflow file did not include a step to build and push the Docker image to Docker Hub. This commit adds a new step to the workflow that uses the `docker/build-push-action` action to build and push the Docker image. The action is configured to use the current directory as the build context, enable caching, and push the image to Docker Hub. The action is also configured to build the image for both `linux/amd64` and `linux/arm64` platforms. The image is tagged with multiple tags, including `latest`, the extension version, and the minor version.