### PR TITLE
DAT-16858      DevOps :: Docker failures for OSS release v4.26.0

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,10 +7,6 @@ on:
       liquibaseVersion:
         description: "Liquibase Version"
         required: true
-      lpmVersion:
-        description: "lpm Version"
-        required: true
-        default: "0.2.4"
       extensionVersion:
         description: "Container Version (Defaults to Liquibase Version)"
         required: false
@@ -18,6 +14,8 @@ on:
 jobs:
 
   update-dockerfiles:
+    env:
+      LPM_VERSION: "0.2.4"
     name: "Update Dockerfiles"
     runs-on: ubuntu-latest
     outputs:
@@ -74,11 +72,14 @@ jobs:
         run: |
           file_list=("Dockerfile" "Dockerfile.alpine")
           LIQUIBASE_SHA=`curl -LsS https://github.com/liquibase/liquibase/releases/download/v${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }'`
-          LPM_SHA=`curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ inputs.lpmVersion }}/lpm-${{ inputs.lpmVersion }}-linux.zip | sha256sum | awk '{ print $1 }'`
+          LPM_SHA=`curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip | sha256sum | awk '{ print $1 }'`
+          LPM_SHA_ARM=`curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux-arm.zip | sha256sum | awk '{ print $1 }'`
+
           for file in "${file_list[@]}"; do
             sed -i 's/^ARG LIQUIBASE_VERSION=.*/ARG LIQUIBASE_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' "${{ github.workspace }}/${file}"
             sed -i 's/^ARG LB_SHA256=.*/ARG LB_SHA256='"$LIQUIBASE_SHA"'/' "${{ github.workspace }}/${file}"
             sed -i 's/^ARG LPM_SHA256=.*/ARG LPM_SHA256='"$LPM_SHA"'/' "${{ github.workspace }}/${file}"
+            sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
             git add "${file}"
           done
           if git diff-index --cached --quiet HEAD --


### PR DESCRIPTION
chore(create-release.yml): remove lpmVersion input and set LPM_VERSION environment variable to "0.2.4" as default

chore(create-release.yml): add support for LPM_SHA256_ARM argument in Dockerfiles to enable ARM architecture support