### PR TITLE
DAT-16878      DevOps :: Docker - LPM ARM sha error

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -73,7 +73,7 @@ jobs:
           file_list=("Dockerfile" "Dockerfile.alpine")
           LIQUIBASE_SHA=`curl -LsS https://github.com/liquibase/liquibase/releases/download/v${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }'`
           LPM_SHA=`curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip | sha256sum | awk '{ print $1 }'`
-          #LPM_SHA_ARM=`curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux-arm.zip | sha256sum | awk '{ print $1 }'`
+          LPM_SHA_ARM=`curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux-arm64.zip | sha256sum | awk '{ print $1 }'`
 
           for file in "${file_list[@]}"; do
             sed -i 's/^ARG LIQUIBASE_VERSION=.*/ARG LIQUIBASE_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' "${{ github.workspace }}/${file}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir /liquibase/bin && \
     case "$(dpkg --print-architecture)" in \
-      "amd64")  DOWNLOAD_ARCH=""  ;; \
-      "arm64")  DOWNLOAD_ARCH="-arm64" && LPM_SHA256=$LPM_SHA256_ARM ;; \
+      *amd64*)  DOWNLOAD_ARCH=""  ;; \
+      *arm64*)  DOWNLOAD_ARCH="-arm64" && LPM_SHA256=$LPM_SHA256_ARM ;; \
     esac && wget -q -O lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${LPM_VERSION}/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" && \
     echo "$LPM_SHA256 *lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" | sha256sum -c - && \
     unzip lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip -d bin/ && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -30,8 +30,8 @@ ARG LPM_SHA256_ARM=375acfa1e12aa0e11c4af65e231e6471ea8d5eea465fb58b516ea2ffbd18f
 RUN mkdir /liquibase/bin && \
     apk add --no-cache --virtual .fetch-deps wget unzip && \
     case "$(apk --print-architecture)" in \
-      "amd64")  DOWNLOAD_ARCH=""  ;; \
-      "aarch64")  DOWNLOAD_ARCH="-arm64" && LPM_SHA256=$LPM_SHA256_ARM  ;; \
+      *amd64*)  DOWNLOAD_ARCH=""  ;; \
+      *arm64*)  DOWNLOAD_ARCH="-arm64" && LPM_SHA256=$LPM_SHA256_ARM  ;; \
     esac && wget -q -O lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${LPM_VERSION}/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" && \
     echo "$LPM_SHA256 *lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" | sha256sum -c - && \
     unzip lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip -d bin/ && \


### PR DESCRIPTION
fix(create-release.yml): update LPM_SHA_ARM variable to download the correct package for arm64 architecture

fix(Dockerfile): update DOWNLOAD_ARCH variable to correctly handle amd64 and arm64 architectures in the case statement
fix(Dockerfile.alpine): update DOWNLOAD_ARCH variable to correctly handle amd64 and arm64 architectures in the case statement