### PR TITLE
Add changelog classpath volumes back to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,5 +53,10 @@ COPY liquibase.docker.properties ./
 # Set user and group
 USER liquibase:liquibase
 
+## This is not used for anything beyond an alternative location for "/liquibase/changelog", but remains for backwards compatibility
+VOLUME /liquibase/classpath
+
+VOLUME /liquibase/changelog
+
 ENTRYPOINT ["/liquibase/docker-entrypoint.sh"]
 CMD ["--help"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -51,5 +51,10 @@ COPY liquibase.docker.properties ./
 
 USER liquibase:liquibase
 
+## This is not used for anything beyond an alternative location for "/liquibase/changelog", but remains for backwards compatibility
+VOLUME /liquibase/classpath
+
+VOLUME /liquibase/changelog
+
 ENTRYPOINT ["/liquibase/docker-entrypoint.sh"]
 CMD ["--help"]


### PR DESCRIPTION
If folder /liquibase/changelog doesn’t exist in the image, Liquibase fails. I had to create this folder as empty