### PR TITLE
use macos-12 as colima not supported on macos-14 (arm)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         dockerfile: [Dockerfile, Dockerfile.alpine]
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-12]
 
     name: Build & Test ${{ matrix.dockerfile }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Docker Desktop on macOS
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-12'
         run: |
           brew install docker
           colima start

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         dockerfile: [Dockerfile, Dockerfile.alpine]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
 
     name: Build & Test ${{ matrix.dockerfile }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Docker Desktop on macOS
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         run: |
           brew install docker
           colima start


### PR DESCRIPTION
fixes issue caused by https://github.com/abiosoft/colima/issues/1023