### PR TITLE
Fix cve-2024-24790

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquiba
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
 
-ARG LPM_VERSION=0.2.5
-ARG LPM_SHA256=2ff5af7e850be8d768fb9e7ef2650e1584aec5bb2a7e92d34a7c71a25e7ff319
-ARG LPM_SHA256_ARM=53197f652100a7cbc42851b300482c86846908d842400eabcf03eea3554b48f8
+ARG LPM_VERSION=0.2.6
+ARG LPM_SHA256=0e1df6b8daf9d53a2d1d90fa8e48abbcbb8e885d249de7a09879a3a0276bebdf
+ARG LPM_SHA256_ARM=b1f6d5c8b21353b213ef828849c3d767d4214e13e8c0f4fbadd038c96ef93389
 
 # Download and Install lpm
 RUN apt-get update && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -26,9 +26,9 @@ RUN set -x && \
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
 
-ARG LPM_VERSION=0.2.5
-ARG LPM_SHA256=2ff5af7e850be8d768fb9e7ef2650e1584aec5bb2a7e92d34a7c71a25e7ff319
-ARG LPM_SHA256_ARM=53197f652100a7cbc42851b300482c86846908d842400eabcf03eea3554b48f8
+ARG LPM_VERSION=0.2.6
+ARG LPM_SHA256=0e1df6b8daf9d53a2d1d90fa8e48abbcbb8e885d249de7a09879a3a0276bebdf
+ARG LPM_SHA256_ARM=b1f6d5c8b21353b213ef828849c3d767d4214e13e8c0f4fbadd038c96ef93389
 
 # Download and Install lpm
 RUN mkdir /liquibase/bin && \


### PR DESCRIPTION
⬆️ Update LPM_VERSION to 0.2.6 and corresponding SHA256 checksums in Dockerfile and Dockerfile.alpine to use the latest version of lpm for improved functionality and security.