### PR TITLE
⬆️ Update LPM_SHA256 corresponding SHA256 checksums in Dockerfile and Dockerfile.alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquiba
     liquibase --version
 
 ARG LPM_VERSION=0.2.6
-ARG LPM_SHA256=c3ecdc0fc0be75181b40e189289bf7fdb3fa62310a1d2cf768483b34e1d541cf
+ARG LPM_SHA256=0e1df6b8daf9d53a2d1d90fa8e48abbcbb8e885d249de7a09879a3a0276bebdf
 ARG LPM_SHA256_ARM=b1f6d5c8b21353b213ef828849c3d767d4214e13e8c0f4fbadd038c96ef93389
 
 # Download and Install lpm

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -27,7 +27,7 @@ RUN set -x && \
     liquibase --version
 
 ARG LPM_VERSION=0.2.6
-ARG LPM_SHA256=c3ecdc0fc0be75181b40e189289bf7fdb3fa62310a1d2cf768483b34e1d541cf
+ARG LPM_SHA256=0e1df6b8daf9d53a2d1d90fa8e48abbcbb8e885d249de7a09879a3a0276bebdf
 ARG LPM_SHA256_ARM=b1f6d5c8b21353b213ef828849c3d767d4214e13e8c0f4fbadd038c96ef93389
 
 # Download and Install lpm


### PR DESCRIPTION
for some reason, the older PR https://github.com/liquibase/docker/commit/0b548684abd167bf2fa43f5dfe48df4185a60637 did not have the new sha in `main` branch 
fix: `Dockerfile`
fix: `Dockerfile.alpine`
