### PR TITLE
⬆️ Update LPM_VERSION from 0.2.7 to 0.2.8

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,7 +20,7 @@ jobs:
 
   update-dockerfiles:
     env:
-      LPM_VERSION: "0.2.7"
+      LPM_VERSION: "0.2.8"
     name: "Update Dockerfiles"
     runs-on: ubuntu-latest
     outputs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquiba
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
 
-ARG LPM_VERSION=0.2.7
-ARG LPM_SHA256=e831120c566c76a427c6d3489cd62d5447322444399393e3ef304db0c036c4a1
-ARG LPM_SHA256_ARM=720afb6bafb987ab502b86682f410d0e19da45fdf0119d947ed7bfa4e6a02665
+ARG LPM_VERSION=0.2.8
+ARG LPM_SHA256=ad46e7f0ca67e39ddbf1435c0bd2879be8a43340c7b627a2da45c07787574200
+ARG LPM_SHA256_ARM=2a2e46f2260f46ccd39f487dca161b4e04d97664160925c5e415bd9b54a23e1a
 
 # Download and Install lpm
 RUN apt-get update && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -26,9 +26,9 @@ RUN set -x && \
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
 
-ARG LPM_VERSION=0.2.7
-ARG LPM_SHA256=e831120c566c76a427c6d3489cd62d5447322444399393e3ef304db0c036c4a1
-ARG LPM_SHA256_ARM=720afb6bafb987ab502b86682f410d0e19da45fdf0119d947ed7bfa4e6a02665
+ARG LPM_VERSION=0.2.8
+ARG LPM_SHA256=ad46e7f0ca67e39ddbf1435c0bd2879be8a43340c7b627a2da45c07787574200
+ARG LPM_SHA256_ARM=2a2e46f2260f46ccd39f487dca161b4e04d97664160925c5e415bd9b54a23e1a
 
 # Download and Install lpm
 RUN mkdir /liquibase/bin && \


### PR DESCRIPTION
⬆️ (create-release.yml): Update LPM_VERSION from 0.2.7 to 0.2.8 in the workflow file to use the latest version of LPM

⬆️ (Dockerfile, Dockerfile.alpine): Update LPM_VERSION from 0.2.7 to 0.2.8 and corresponding SHA256 checksums to match the new version of LPM for consistency and security reasons