### PR TITLE
🔧 DAT-18995: revert changes made by liquibot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN groupadd --gid 1001 liquibase && \
 # Download and install Liquibase
 WORKDIR /liquibase
 
-ARG LIQUIBASE_VERSION=dry-run-11811561251
-ARG LB_SHA256=0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5
+ARG LIQUIBASE_VERSION=4.30.0
+ARG LB_SHA256=184ffd609518091da42d6cd75e883b4f6ff1763cce8883e95fc99f7f05ca262d
 
 RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" && \
     echo "$LB_SHA256 *liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -11,8 +11,8 @@ RUN apk add --no-cache openjdk17-jre-headless bash
 
 WORKDIR /liquibase
 
-ARG LIQUIBASE_VERSION=dry-run-11811561251
-ARG LB_SHA256=0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5
+ARG LIQUIBASE_VERSION=4.30.0
+ARG LB_SHA256=184ffd609518091da42d6cd75e883b4f6ff1763cce8883e95fc99f7f05ca262d
 
 # Download, verify, extract
 RUN set -x && \


### PR DESCRIPTION
This pull request updates the Liquibase version and its associated SHA256 checksum in the Docker configuration files. 

Version updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L17-R18): Updated `LIQUIBASE_VERSION` to `4.30.0` and `LB_SHA256` to `184ffd609518091da42d6cd75e883b4f6ff1763cce8883e95fc99f7f05ca262d`.
* [`Dockerfile.alpine`](diffhunk://#diff-f865864730d7062c04cc13b1b85ba03ed5dbef3fa02fcb50b87d9117d0af1f4eL14-R15): Updated `LIQUIBASE_VERSION` to `4.30.0` and `LB_SHA256` to `184ffd609518091da42d6cd75e883b4f6ff1763cce8883e95fc99f7f05ca262d`.