### PR TITLE
🛠️ TEST DAT-18995: comment code to test if PR gets created on a dryRun 

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -81,125 +81,125 @@ jobs:
           git config user.name "liquibot"
           git config user.email "liquibot@liquibase.org"
           
-      - name: Update Dockerfile and commit changes
-        run: |
-          file_list=("Dockerfile" "Dockerfile.alpine")
-          LIQUIBASE_SHA=`curl -LsS https://github.com/liquibase/liquibase/releases/download/v${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }'`
-          LPM_SHA=`curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip | sha256sum | awk '{ print $1 }'`
-          LPM_SHA_ARM=`curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux-arm64.zip | sha256sum | awk '{ print $1 }'`
-
-          for file in "${file_list[@]}"; do
-            sed -i 's/^ARG LIQUIBASE_VERSION=.*/ARG LIQUIBASE_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' "${{ github.workspace }}/${file}"
-            sed -i 's/^ARG LB_SHA256=.*/ARG LB_SHA256='"$LIQUIBASE_SHA"'/' "${{ github.workspace }}/${file}"
-            sed -i 's/^ARG LPM_SHA256=.*/ARG LPM_SHA256='"$LPM_SHA"'/' "${{ github.workspace }}/${file}"
-            #sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
-            git add "${file}"
-          done
-          if git diff-index --cached --quiet HEAD --
-          then
-            echo "Nothing new to commit"
-          else
-            git commit -m "Liquibase Version Bumped to ${{ steps.collect-data.outputs.extensionVersion }}"
-            if [[ "${{ steps.collect-data.outputs.dryRun }}" == false ]]; then
-              git tag -fa -m "Version Bumped to ${{ steps.collect-data.outputs.extensionVersion }}" v${{ steps.collect-data.outputs.extensionVersion }}
-              git push -f "https://liquibot:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.ref }} --follow-tags --tags
-            else
-              echo "Dry run mode: changes have not been pushed."
-            fi
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-
-      - name: Get latest commit SHA
-        id: get-latest-sha
-        run: echo "latestCommitSha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-  setup-update-draft-build:
-    name: "${{ matrix.image.name }}:${{ inputs.liquibaseVersion}}${{ matrix.image.suffix }}"
-    needs: update-dockerfiles
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        image: [ 
-          {dockerfile: Dockerfile, name: liquibase/liquibase, suffix: "", latest_tag: "latest"},
-          {dockerfile: Dockerfile.alpine, name: liquibase/liquibase, suffix: "-alpine", latest_tag: "alpine"},
-          ]
-    steps:      
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
-          ref: ${{ github.ref }}
-          
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: "8"
-          distribution: "adopt"
-
-      - name: Release Notes
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          name: v${{ needs.update-dockerfiles.outputs.extensionVersion}}
-          tag_name: v${{ needs.update-dockerfiles.outputs.extensionVersion }}
-          draft: true
-          body: Support for Liquibase ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-  
-      - name: Login to ECR Registry
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-        uses: docker/login-action@v3
-        env:
-          AWS_REGION: us-east-1
-        with:
-          registry: public.ecr.aws
-          username: ${{ secrets.PUBLIC_ECR_ACCESS_KEY_ID }}
-          password: ${{ secrets.PUBLIC_ECR_SECRET_ACCESS_KEY }}
-
-      - name: Login to ECR Private Registry (dry-run)
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'true' }}
-        uses: docker/login-action@v3
-        env:
-          AWS_REGION: us-east-1
-        with:
-          registry: ${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}
-          username: ${{ secrets.PUBLIC_ECR_ACCESS_KEY_ID }}
-          password: ${{ secrets.PUBLIC_ECR_SECRET_ACCESS_KEY }}
-              
-      - name: Build and Push Docker Image
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-        env:
-          ECR_REGISTRY: public.ecr.aws/liquibase/liquibase
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ matrix.image.dockerfile }}
-          no-cache: true
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ matrix.image.name }}:${{ matrix.image.latest_tag }},${{ matrix.image.name }}:${{ needs.update-dockerfiles.outputs.extensionVersion }}${{ matrix.image.suffix }},${{ matrix.image.name }}:${{ needs.update-dockerfiles.outputs.minorVersion }}${{ matrix.image.suffix }},${{ env.ECR_REGISTRY }}:${{ matrix.image.latest_tag }},${{ env.ECR_REGISTRY }}:${{ needs.update-dockerfiles.outputs.extensionVersion }}${{ matrix.image.suffix }},${{ env.ECR_REGISTRY }}:${{ needs.update-dockerfiles.outputs.minorVersion }}${{ matrix.image.suffix }}
-
-      - name: Build and Push Docker Image (dry-run)
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'true' }}
-        env:
-          ECR_REGISTRY: ${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ matrix.image.dockerfile }}
-          no-cache: true
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ env.ECR_REGISTRY }}:${{ matrix.image.latest_tag }},${{ env.ECR_REGISTRY }}:${{ needs.update-dockerfiles.outputs.extensionVersion }}${{ matrix.image.suffix }},${{ env.ECR_REGISTRY }}:${{ needs.update-dockerfiles.outputs.minorVersion }}${{ matrix.image.suffix }}
+#      - name: Update Dockerfile and commit changes
+#        run: |
+#          file_list=("Dockerfile" "Dockerfile.alpine")
+#          LIQUIBASE_SHA=`curl -LsS https://github.com/liquibase/liquibase/releases/download/v${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }'`
+#          LPM_SHA=`curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip | sha256sum | awk '{ print $1 }'`
+#          LPM_SHA_ARM=`curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux-arm64.zip | sha256sum | awk '{ print $1 }'`
+#
+#          for file in "${file_list[@]}"; do
+#            sed -i 's/^ARG LIQUIBASE_VERSION=.*/ARG LIQUIBASE_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' "${{ github.workspace }}/${file}"
+#            sed -i 's/^ARG LB_SHA256=.*/ARG LB_SHA256='"$LIQUIBASE_SHA"'/' "${{ github.workspace }}/${file}"
+#            sed -i 's/^ARG LPM_SHA256=.*/ARG LPM_SHA256='"$LPM_SHA"'/' "${{ github.workspace }}/${file}"
+#            #sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
+#            git add "${file}"
+#          done
+#          if git diff-index --cached --quiet HEAD --
+#          then
+#            echo "Nothing new to commit"
+#          else
+#            git commit -m "Liquibase Version Bumped to ${{ steps.collect-data.outputs.extensionVersion }}"
+#            if [[ "${{ steps.collect-data.outputs.dryRun }}" == false ]]; then
+#              git tag -fa -m "Version Bumped to ${{ steps.collect-data.outputs.extensionVersion }}" v${{ steps.collect-data.outputs.extensionVersion }}
+#              git push -f "https://liquibot:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.ref }} --follow-tags --tags
+#            else
+#              echo "Dry run mode: changes have not been pushed."
+#            fi
+#          fi
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+#
+#      - name: Get latest commit SHA
+#        id: get-latest-sha
+#        run: echo "latestCommitSha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+#
+#  setup-update-draft-build:
+#    name: "${{ matrix.image.name }}:${{ inputs.liquibaseVersion}}${{ matrix.image.suffix }}"
+#    needs: update-dockerfiles
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        image: [
+#          {dockerfile: Dockerfile, name: liquibase/liquibase, suffix: "", latest_tag: "latest"},
+#          {dockerfile: Dockerfile.alpine, name: liquibase/liquibase, suffix: "-alpine", latest_tag: "alpine"},
+#          ]
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+#          ref: ${{ github.ref }}
+#
+#      - name: Set up JDK
+#        uses: actions/setup-java@v4
+#        with:
+#          java-version: "8"
+#          distribution: "adopt"
+#
+#      - name: Release Notes
+#        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+#        uses: softprops/action-gh-release@v2
+#        with:
+#          name: v${{ needs.update-dockerfiles.outputs.extensionVersion}}
+#          tag_name: v${{ needs.update-dockerfiles.outputs.extensionVersion }}
+#          draft: true
+#          body: Support for Liquibase ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}.
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - uses: docker/setup-qemu-action@v3
+#      - uses: docker/setup-buildx-action@v3
+#      - uses: docker/login-action@v3
+#        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#      - name: Login to ECR Registry
+#        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+#        uses: docker/login-action@v3
+#        env:
+#          AWS_REGION: us-east-1
+#        with:
+#          registry: public.ecr.aws
+#          username: ${{ secrets.PUBLIC_ECR_ACCESS_KEY_ID }}
+#          password: ${{ secrets.PUBLIC_ECR_SECRET_ACCESS_KEY }}
+#
+#      - name: Login to ECR Private Registry (dry-run)
+#        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'true' }}
+#        uses: docker/login-action@v3
+#        env:
+#          AWS_REGION: us-east-1
+#        with:
+#          registry: ${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}
+#          username: ${{ secrets.PUBLIC_ECR_ACCESS_KEY_ID }}
+#          password: ${{ secrets.PUBLIC_ECR_SECRET_ACCESS_KEY }}
+#
+#      - name: Build and Push Docker Image
+#        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+#        env:
+#          ECR_REGISTRY: public.ecr.aws/liquibase/liquibase
+#        uses: docker/build-push-action@v6
+#        with:
+#          context: .
+#          file: ${{ matrix.image.dockerfile }}
+#          no-cache: true
+#          push: true
+#          platforms: linux/amd64,linux/arm64
+#          tags: ${{ matrix.image.name }}:${{ matrix.image.latest_tag }},${{ matrix.image.name }}:${{ needs.update-dockerfiles.outputs.extensionVersion }}${{ matrix.image.suffix }},${{ matrix.image.name }}:${{ needs.update-dockerfiles.outputs.minorVersion }}${{ matrix.image.suffix }},${{ env.ECR_REGISTRY }}:${{ matrix.image.latest_tag }},${{ env.ECR_REGISTRY }}:${{ needs.update-dockerfiles.outputs.extensionVersion }}${{ matrix.image.suffix }},${{ env.ECR_REGISTRY }}:${{ needs.update-dockerfiles.outputs.minorVersion }}${{ matrix.image.suffix }}
+#
+#      - name: Build and Push Docker Image (dry-run)
+#        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'true' }}
+#        env:
+#          ECR_REGISTRY: ${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}
+#        uses: docker/build-push-action@v6
+#        with:
+#          context: .
+#          file: ${{ matrix.image.dockerfile }}
+#          no-cache: true
+#          push: true
+#          platforms: linux/amd64,linux/arm64
+#          tags: ${{ env.ECR_REGISTRY }}:${{ matrix.image.latest_tag }},${{ env.ECR_REGISTRY }}:${{ needs.update-dockerfiles.outputs.extensionVersion }}${{ matrix.image.suffix }},${{ env.ECR_REGISTRY }}:${{ needs.update-dockerfiles.outputs.minorVersion }}${{ matrix.image.suffix }}
 
 
   update-official-repo:
@@ -225,55 +225,59 @@ jobs:
           ref: master
           token: ${{ env.GITHUB_TOKEN }}
 
-      - name: Update library/liquibase in liquibase/official-images
-        run: |
-            echo "Maintainers: Jake Newton <docker@liquibase.com> (@jnewton03)" > library/liquibase
-            echo "Architectures: arm64v8, amd64" >> library/liquibase
-            echo "GitRepo: https://github.com/liquibase/docker.git" >> library/liquibase
-            echo "" >> library/liquibase
-            echo "Tags: ${{ env.MAJOR_MINOR }}, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}, latest" >> library/liquibase
-            echo "GitFetch: refs/heads/main" >> library/liquibase
-            echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
-            echo "File: Dockerfile" >> library/liquibase
-            echo "" >> library/liquibase
-            echo "Tags: ${{ env.MAJOR_MINOR }}-alpine, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}-alpine, alpine" >> library/liquibase
-            echo "GitFetch: refs/heads/main" >> library/liquibase
-            echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
-            echo "File: Dockerfile.alpine" >> library/liquibase
-            git add library/liquibase
-            if git diff-index --cached --quiet HEAD --
-              then
-                echo "Nothing new to commit"
-              else
-                git config user.name "liquibot"
-                git config user.email "liquibot@liquibase.org"
-                git commit -m "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
-                if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == false ]]; then
-                  git push https://liquibot:$GITHUB_TOKEN@github.com/liquibase/official-images.git
-                else
-                echo "Dry run mode: changes have not been pushed."
-              fi
-            fi
+#      - name: Update library/liquibase in liquibase/official-images
+#        run: |
+#            echo "Maintainers: Jake Newton <docker@liquibase.com> (@jnewton03)" > library/liquibase
+#            echo "Architectures: arm64v8, amd64" >> library/liquibase
+#            echo "GitRepo: https://github.com/liquibase/docker.git" >> library/liquibase
+#            echo "" >> library/liquibase
+#            echo "Tags: ${{ env.MAJOR_MINOR }}, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}, latest" >> library/liquibase
+#            echo "GitFetch: refs/heads/main" >> library/liquibase
+#            echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
+#            echo "File: Dockerfile" >> library/liquibase
+#            echo "" >> library/liquibase
+#            echo "Tags: ${{ env.MAJOR_MINOR }}-alpine, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}-alpine, alpine" >> library/liquibase
+#            echo "GitFetch: refs/heads/main" >> library/liquibase
+#            echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
+#            echo "File: Dockerfile.alpine" >> library/liquibase
+#            git add library/liquibase
+#            if git diff-index --cached --quiet HEAD --
+#              then
+#                echo "Nothing new to commit"
+#              else
+#                git config user.name "liquibot"
+#                git config user.email "liquibot@liquibase.org"
+#                git commit -m "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
+#                if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == false ]]; then
+#                  git push https://liquibot:$GITHUB_TOKEN@github.com/liquibase/official-images.git
+#                else
+#                echo "Dry run mode: changes have not been pushed."
+#              fi
+#            fi
+      - name: Print dryRun value
+        run: echo ${{ needs.update-dockerfiles.outputs.dryRun }}
 
       - name: Create Official Docker Pull Request
         if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
         id: create_pr
         run: |
-          response=$(curl \
-            -X POST \
-            -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/docker-library/official-images/pulls \
-            -d '{
-              "title": "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}",
-              "body": "Update library/liquibase with latest commit and version",
-              "head": "liquibase:master",
-              "base": "master"
-            }')
-          pr_url=$(echo $response | jq -r '.html_url')
-          echo "PR_URL=$pr_url" >> $GITHUB_ENV
+          echo "Hello"
 
-      - name: Adding Official Docker PR to job summary
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-        run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY
+#          response=$(curl \
+#            -X POST \
+#            -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
+#            -H "Accept: application/vnd.github.v3+json" \
+#            https://api.github.com/repos/docker-library/official-images/pulls \
+#            -d '{
+#              "title": "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}",
+#              "body": "Update library/liquibase with latest commit and version",
+#              "head": "liquibase:master",
+#              "base": "master"
+#            }')
+#          pr_url=$(echo $response | jq -r '.html_url')
+#          echo "PR_URL=$pr_url" >> $GITHUB_ENV
+#
+#      - name: Adding Official Docker PR to job summary
+#        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+#        run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY
         


### PR DESCRIPTION
This pull request involves significant changes to the `.github/workflows/create-release.yml` file, mostly commenting out existing steps and adding a new step to print the `dryRun` value. Here are the most important changes:

### NEEDED to TEST dryRun:

- Due to this piece of code [HERE](https://github.com/liquibase/liquibase/blob/test/DAT-18995/.github/workflows/release-published.yml#L470-L491) , there is no way of sending ref branch in `createDispatchEvent` as it always triggers the workflow on the default branch of the repository (https://octokit.github.io/rest.js/v21/) . Therefore, I am planning to comment the docker piece of code in main branch of docker like shown in the snippet for a quick test.

### New Steps:

* Added a new step to print the `dryRun` value.

**NOTE: this PR will be reverted after testing is done** 