### PR TITLE
fix(Dockerfile): set explicit home directory for Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM eclipse-temurin:17-jre-jammy
 
 # Create liquibase user
 RUN groupadd --gid 1001 liquibase && \
-    useradd --uid 1001 --gid liquibase liquibase && \
-    mkdir /liquibase && chown liquibase /liquibase
+    useradd --uid 1001 --gid liquibase --create-home --home-dir /liquibase liquibase && \
+    chown liquibase /liquibase
 
 # Install necessary dependencies
 #RUN apt-get update && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -3,8 +3,8 @@ FROM alpine:3.20
 
 # Create liquibase user
 RUN addgroup --gid 1001 liquibase && \
-    adduser --disabled-password --uid 1001 --ingroup liquibase liquibase && \
-    mkdir /liquibase && chown liquibase /liquibase
+    adduser --disabled-password --uid 1001 --ingroup liquibase --home /liquibase liquibase && \
+    chown liquibase /liquibase
 
 # Install smaller JRE, if available and acceptable
 RUN apk add --no-cache openjdk17-jre-headless bash


### PR DESCRIPTION
This pull request includes updates to the Dockerfiles to streamline the creation of the `liquibase` user and its home directory. The changes ensure that the home directory is created automatically during user creation.

Updates to Dockerfiles:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L6-R7): Modified the `useradd` command to use the `--create-home` and `--home-dir` options, ensuring the home directory is created during user creation.
* [`Dockerfile.alpine`](diffhunk://#diff-f865864730d7062c04cc13b1b85ba03ed5dbef3fa02fcb50b87d9117d0af1f4eL6-R7): Updated the `adduser` command to include the `--home` option, creating the home directory automatically during user creation.