### PR TITLE
🔧 Ensure the repo is in sync with the latest state from the remote.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -80,7 +80,8 @@ jobs:
         run: |
           git config user.name "liquibot"
           git config user.email "liquibot@liquibase.org"
-          
+              
+            
       - name: Update Dockerfile and commit changes
         run: |
           file_list=("Dockerfile" "Dockerfile.alpine")
@@ -209,6 +210,17 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
     steps:
+      - name: Fetch and Rebase Official Images Repository
+        run: |
+          git clone https://github.com/docker-library/official-images.git
+          cd official-images
+          git fetch origin master
+          git checkout master
+          # Reset liquibase:master to match official master
+          git checkout -B liquibase:master
+          git reset --hard origin/master
+          # Push the reset liquibase:master back to the remote repository
+          git push origin liquibase:master --force
 
       - name: Extract major.minor version
         id: extract_version


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/create-release.yml` file to improve the release workflow. Add steps to fetch and rebase official images repository in release workflow. Ensures the repo is in sync with the latest state from the remote.

Workflow improvements:

* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R213-R223): Added a new step to fetch and rebase the official images repository to ensure the `liquibase:master` branch matches the official master branch.
* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R84): Added a blank line for better readability.