### PR TITLE
🔧 upgrade to using v4 upload-artifact@v4

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -77,15 +77,15 @@ jobs:
         uses: rsdmike/github-security-report-action@v3.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          outputDir: ./reports/
+          outputDir: ./reports/trivy${{ matrix.image.suffix }}/
           sarifReportDir: .
 
       - name: Upload Security Report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: security-report-trivy-${{ matrix.image.name }}${{ matrix.image.suffix }}
-          path: ./reports/summary.pdf
+          name: security-report-trivy${{ matrix.image.suffix }}
+          path: ./reports/trivy${{ matrix.image.suffix }}/summary.pdf
 
 
   scout:
@@ -153,12 +153,12 @@ jobs:
         uses: rsdmike/github-security-report-action@v3.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          outputDir: ./reports/
+          outputDir: ./reports/scout${{ matrix.image.suffix }}/
           sarifReportDir: .
 
       - name: Upload Security Report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: security-report-scout-${{ matrix.image.name }}${{ matrix.image.suffix }}
-          path: ./reports/summary.pdf
+          name: security-report-scout${{ matrix.image.suffix }}
+          path: ./reports/scout${{ matrix.image.suffix }}/summary.pdf

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -84,7 +84,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: security-report-trivy-${{ matrix.runs-on }}
+          name: security-report-trivy-${{ matrix.image.name }}${{ matrix.image.suffix }}
           path: ./reports/summary.pdf
 
 
@@ -160,5 +160,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: security-report-scout-${{ matrix.runs-on }}
+          name: security-report-scout-${{ matrix.image.name }}${{ matrix.image.suffix }}
           path: ./reports/summary.pdf

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -84,7 +84,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: security-report-trivy
+          name: security-report-trivy-${{ matrix.runs-on }}
           path: ./reports/summary.pdf
 
 
@@ -160,5 +160,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: security-report-scout
+          name: security-report-scout-${{ matrix.runs-on }}
           path: ./reports/summary.pdf

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload Security Report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: security-report-trivy
           path: ./reports/summary.pdf
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload Security Report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: security-report-scout
           path: ./reports/summary.pdf


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/trivy.yml` file to improve the security report upload process.

Version updates for GitHub Actions:

* Updated the `actions/upload-artifact` action from version `v3` to `v4` for uploading the security report in two places within the `jobs:` section. [[1]](diffhunk://#diff-c0c68244c39d0231fb6c8bf8113bb4673a9f6e833bdbc78f11904647ff40a46bL85-R85) [[2]](diffhunk://#diff-c0c68244c39d0231fb6c8bf8113bb4673a9f6e833bdbc78f11904647ff40a46bL161-R161)