### PR TITLE
DAT-19447  Fix https://github.com/Codex-/return-dispatch/issues/188

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,6 +15,11 @@ on:
         required: true
         type: boolean
         default: false
+      distinct_id:
+        description: "Only needed for liquibase dispatch"
+        required: false
+        type: string
+        default: ""
 
 jobs:
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/create-release.yml` file. The change adds a new parameter `distinct_id` to the workflow configuration, which is described as only needed for Liquibase dispatch.

* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R18-R22): Added a new optional parameter `distinct_id` with a default value of an empty string.