### PR TITLE
Update README.md for Configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ docker run --rm -v /path/to/changelog:/liquibase/changelog liquibase/liquibase -
 
 ### ⚙️ Using a Configuration File
 
-To use a default configuration file, mount it in your changelog volume and reference it with the `--defaultsFile` argument.
+To use a default configuration file, mount it in your liquibase.properties file and reference it with the `--defaultsFile` argument.
 
 #### Example
 
 ```shell
-docker run --rm -v /path/to/changelog:/liquibase/changelog liquibase/liquibase --defaultsFile=liquibase.properties update
+docker run --rm -v /path/to/liquibase.properties:/liquibase/liquibase.properties/liquibase --defaultsFile=liquibase.properties update
 ```
 
 ### 📚 Including Drivers and Extensions


### PR DESCRIPTION
Based on a conversation I had with @StevenMassaro, I believe this example for the Configuration files section should use the liquibase.properties file as an example rather than a changelog. Please review this to be sure the example is correct before publishing. Thanks!