### PR TITLE
DAT-19508 DevOps :: Update AWS MP container with liquibase-aws-extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquiba
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
 
-ARG LPM_VERSION=0.2.8
-ARG LPM_SHA256=ad46e7f0ca67e39ddbf1435c0bd2879be8a43340c7b627a2da45c07787574200
-ARG LPM_SHA256_ARM=2a2e46f2260f46ccd39f487dca161b4e04d97664160925c5e415bd9b54a23e1a
+ARG LPM_VERSION=0.2.9
+ARG LPM_SHA256=423673ad9bbb1711cd6b4db004223f3d927f5cda8c17f7f92cb10b882059d2c8
+ARG LPM_SHA256_ARM=d3080a913cb17a0346ff27229ce06090d8bb1f29d719c33087a36aa29705fc20
 
 # Download and Install lpm
 RUN apt-get update && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -26,9 +26,9 @@ RUN set -x && \
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
 
-ARG LPM_VERSION=0.2.8
-ARG LPM_SHA256=ad46e7f0ca67e39ddbf1435c0bd2879be8a43340c7b627a2da45c07787574200
-ARG LPM_SHA256_ARM=2a2e46f2260f46ccd39f487dca161b4e04d97664160925c5e415bd9b54a23e1a
+ARG LPM_VERSION=0.2.9
+ARG LPM_SHA256=423673ad9bbb1711cd6b4db004223f3d927f5cda8c17f7f92cb10b882059d2c8
+ARG LPM_SHA256_ARM=d3080a913cb17a0346ff27229ce06090d8bb1f29d719c33087a36aa29705fc20
 
 # Download and Install lpm
 RUN mkdir /liquibase/bin && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -58,3 +58,4 @@ USER liquibase:liquibase
 
 ENTRYPOINT ["/liquibase/docker-entrypoint.sh"]
 CMD ["--help"]
+

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -58,4 +58,3 @@ USER liquibase:liquibase
 
 ENTRYPOINT ["/liquibase/docker-entrypoint.sh"]
 CMD ["--help"]
-


### PR DESCRIPTION
This pull request includes updates to the `Dockerfile` and `Dockerfile.alpine` to upgrade the version of `lpm` and its associated SHA256 checksums.

Version updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L28-R30): Updated `LPM_VERSION` to `0.2.9` and modified `LPM_SHA256` and `LPM_SHA256_ARM` to their new values.
* [`Dockerfile.alpine`](diffhunk://#diff-f865864730d7062c04cc13b1b85ba03ed5dbef3fa02fcb50b87d9117d0af1f4eL29-R31): Updated `LPM_VERSION` to `0.2.9` and modified `LPM_SHA256` and `LPM_SHA256_ARM` to their new values.