### PR TITLE
Update Java to 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder Stage
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:21-jre-jammy
 
 # Create liquibase user
 RUN groupadd --gid 1001 liquibase && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -7,7 +7,7 @@ RUN addgroup --gid 1001 liquibase && \
     chown liquibase /liquibase
 
 # Install smaller JRE, if available and acceptable
-RUN apk add --no-cache openjdk17-jre-headless bash
+RUN apk add --no-cache openjdk21-jre-headless bash
 
 WORKDIR /liquibase
 


### PR DESCRIPTION
fix #366 

This pull request includes updates to the Dockerfile configurations to use newer versions of the Java Runtime Environment (JRE). The most important changes are:

JRE version updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R2): Updated the base image from `eclipse-temurin:17-jre-jammy` to `eclipse-temurin:21-jre-jammy`.
* [`Dockerfile.alpine`](diffhunk://#diff-f865864730d7062c04cc13b1b85ba03ed5dbef3fa02fcb50b87d9117d0af1f4eL10-R10): Updated the installed JRE from `openjdk17-jre-headless` to `openjdk21-jre-headless`.