### PR TITLE
Revert "Update Java to 21"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder Stage
-FROM eclipse-temurin:21-jre-jammy
+FROM eclipse-temurin:17-jre-jammy
 
 # Create liquibase user
 RUN groupadd --gid 1001 liquibase && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -7,7 +7,7 @@ RUN addgroup --gid 1001 liquibase && \
     chown liquibase /liquibase
 
 # Install smaller JRE, if available and acceptable
-RUN apk add --no-cache openjdk21-jre-headless bash
+RUN apk add --no-cache openjdk17-jre-headless bash
 
 WORKDIR /liquibase
 


### PR DESCRIPTION
Reverts liquibase/docker#370

@jandroav @sayaliM0412 this was causing the trivy/scout scans to fail.  Reverting for now.