### PR TITLE
⬆️ CVE-2025-22871 LPM SHA256 checksums for security and integrity verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquiba
     liquibase --version
 
 ARG LPM_VERSION=0.2.9
-ARG LPM_SHA256=423673ad9bbb1711cd6b4db004223f3d927f5cda8c17f7f92cb10b882059d2c8
-ARG LPM_SHA256_ARM=d3080a913cb17a0346ff27229ce06090d8bb1f29d719c33087a36aa29705fc20
+ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
+ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
 
 # Download and Install lpm
 RUN apt-get update && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -27,8 +27,8 @@ RUN set -x && \
     liquibase --version
 
 ARG LPM_VERSION=0.2.9
-ARG LPM_SHA256=423673ad9bbb1711cd6b4db004223f3d927f5cda8c17f7f92cb10b882059d2c8
-ARG LPM_SHA256_ARM=d3080a913cb17a0346ff27229ce06090d8bb1f29d719c33087a36aa29705fc20
+ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
+ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
 
 # Download and Install lpm
 RUN mkdir /liquibase/bin && \


### PR DESCRIPTION
This pull request updates the checksum values for the Liquibase Package Manager (LPM) in the Dockerfiles to ensure the integrity of the downloaded files. The changes affect both the standard and Alpine-based Dockerfiles.

Checksum updates for LPM:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L29-R30): Updated `LPM_SHA256` and `LPM_SHA256_ARM` values to new checksum values for verifying the integrity of the LPM package.
* [`Dockerfile.alpine`](diffhunk://#diff-f865864730d7062c04cc13b1b85ba03ed5dbef3fa02fcb50b87d9117d0af1f4eL30-R31): Updated `LPM_SHA256` and `LPM_SHA256_ARM` values to match the updated checksum values for the Alpine-based image.