### PR TITLE
Disable lpm tests for liquibase PRO image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,6 +169,7 @@ jobs:
           fi
 
       - name: Test driver connection
+        if: matrix.dockerfile != 'DockerfilePro'
         run: |
           LOG_STRING="successfully installed in classpath"
           echo "Stopping and removing existing container..."
@@ -179,25 +180,9 @@ jobs:
           docker network create --driver bridge test_network || echo "Network may already exist"
           
           echo "Starting container with docker run..."
-          docker run -d --env LIQUIBASE_LICENSE_KEY=${{ secrets.PRO_LICENSE_KEY }} --name $CONTAINER_NAME --network test_network -v $(pwd)/.github/test:/liquibase/changelog liquibase/liquibase:${{ github.sha }} init start-h2
-          
-          echo "Container status after run:"
-          docker ps -a | grep $CONTAINER_NAME
-          
-          echo "Container logs:"
-          docker logs $CONTAINER_NAME
-          
-          echo "Attempting to add mssql driver..."
-          if docker exec $CONTAINER_NAME lpm add mssql --category=driver -g 2>&1 | tee /tmp/driver_output.log | grep -q "$LOG_STRING"; then
-          echo "SUCCESS: The log contains the string: $LOG_STRING"
-          cat /tmp/driver_output.log
-          else
-          echo "ERROR: The log does not contain the string: $LOG_STRING"
-          echo "Full output:"
-          cat /tmp/driver_output.log
+          echo "The log does not contain the string: $LOG_STRING"
           exit 1
           fi
-
 
       - name: Test custom entrypoint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,17 +171,33 @@ jobs:
       - name: Test driver connection
         run: |
           LOG_STRING="successfully installed in classpath"
-          docker stop $CONTAINER_NAME
-          docker rm $CONTAINER_NAME
-          docker network create --driver bridge test_network
-          # Get the logs and check if the desired string is present
+          echo "Stopping and removing existing container..."
+          docker stop $CONTAINER_NAME || true
+          docker rm $CONTAINER_NAME || true
+          
+          echo "Creating test network..."
+          docker network create --driver bridge test_network || echo "Network may already exist"
+          
+          echo "Starting container with docker run..."
           docker run -d --env LIQUIBASE_LICENSE_KEY=${{ secrets.PRO_LICENSE_KEY }} --name $CONTAINER_NAME --network test_network -v $(pwd)/.github/test:/liquibase/changelog liquibase/liquibase:${{ github.sha }} init start-h2
-          if docker exec $CONTAINER_NAME lpm add mssql --category=driver -g 2>&1 | grep -q "$LOG_STRING"; then
-              echo "The log contains the string: $LOG_STRING"
+          
+          echo "Container status after run:"
+          docker ps -a | grep $CONTAINER_NAME
+          
+          echo "Container logs:"
+          docker logs $CONTAINER_NAME
+          
+          echo "Attempting to add mssql driver..."
+          if docker exec $CONTAINER_NAME lpm add mssql --category=driver -g 2>&1 | tee /tmp/driver_output.log | grep -q "$LOG_STRING"; then
+          echo "SUCCESS: The log contains the string: $LOG_STRING"
+          cat /tmp/driver_output.log
           else
-              echo "The log does not contain the string: $LOG_STRING"
-              exit 1
+          echo "ERROR: The log does not contain the string: $LOG_STRING"
+          echo "Full output:"
+          cat /tmp/driver_output.log
+          exit 1
           fi
+
 
       - name: Test custom entrypoint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,55 +158,37 @@ jobs:
         if: matrix.dockerfile != 'DockerfilePro'
         run: |
           LOG_STRING="liquibase-redshift"
-          echo "::group::Adding liquibase-redshift extension"
-          # Stop docker container
+          echo "Installing liquibase-redshift extension with verbose logging..."
+          # Run LPM with verbose output and save the logs
           docker exec $CONTAINER_NAME lpm add liquibase-redshift --category=extension -g
-          echo "::endgroup::"
-          
-          echo "::group::Checking extension installation"
+          docker logs "$CONTAINER_NAME"
+          # Print LPM logs to help with debugging
+          echo "LPM installation completed. Checking if extension was installed..."
           # Get the logs and check if the desired string is present
-          docker exec $CONTAINER_NAME liquibase --version
           if docker exec $CONTAINER_NAME liquibase --version 2>&1 | grep -q "$LOG_STRING"; then
           echo "The log contains the string: $LOG_STRING"
           else
           echo "The log does not contain the string: $LOG_STRING"
+          echo "Extension not found in version output. Full version information:"
+          docker exec $CONTAINER_NAME liquibase --version
           exit 1
           fi
-          echo "::endgroup::"
 
       - name: Test driver connection
         if: matrix.dockerfile != 'DockerfilePro'
         run: |
           LOG_STRING="successfully installed in classpath"
-          echo "::group::Container cleanup"
           echo "Stopping and removing existing container..."
           docker stop $CONTAINER_NAME || true
           docker rm $CONTAINER_NAME || true
-          echo "::endgroup::"
           
-          echo "::group::Network setup"
           echo "Creating test network..."
           docker network create --driver bridge test_network || echo "Network may already exist"
-          echo "::endgroup::"
           
-          echo "::group::Starting container"
           echo "Starting container with docker run..."
-          # Add docker run command with verbose output
-          docker run -d --network test_network --env LIQUIBASE_LICENSE_KEY=${{ secrets.PRO_LICENSE_KEY }} --name $CONTAINER_NAME -v $(pwd)/.github/test:/liquibase/changelog liquibase/liquibase:${{ github.sha }}
-          # Show container logs for debugging
-          echo "Container logs:"
-          docker logs $CONTAINER_NAME
-          echo "::endgroup::"
-          
-          echo "::group::Driver connection test"
-          # Test driver connection - add your actual test here
-          if docker exec $CONTAINER_NAME [your-command-here] 2>&1 | grep -q "$LOG_STRING"; then
-          echo "The log contains the string: $LOG_STRING"
-          else
           echo "The log does not contain the string: $LOG_STRING"
           exit 1
           fi
-          echo "::endgroup::"
 
       - name: Test custom entrypoint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,36 +158,30 @@ jobs:
         if: matrix.dockerfile != 'DockerfilePro'
         run: |
           LOG_STRING="liquibase-redshift"
-          echo "Installing liquibase-redshift extension with verbose logging..."
-          # Run LPM with verbose output and save the logs
+          # Stop docker container
           docker exec $CONTAINER_NAME lpm add liquibase-redshift --category=extension -g
-          docker logs "$CONTAINER_NAME"
-          # Print LPM logs to help with debugging
-          echo "LPM installation completed. Checking if extension was installed..."
           # Get the logs and check if the desired string is present
           if docker exec $CONTAINER_NAME liquibase --version 2>&1 | grep -q "$LOG_STRING"; then
-          echo "The log contains the string: $LOG_STRING"
+              echo "The log contains the string: $LOG_STRING"
           else
-          echo "The log does not contain the string: $LOG_STRING"
-          echo "Extension not found in version output. Full version information:"
-          docker exec $CONTAINER_NAME liquibase --version
-          exit 1
+              echo "The log does not contain the string: $LOG_STRING"
+              exit 1
           fi
 
       - name: Test driver connection
         if: matrix.dockerfile != 'DockerfilePro'
         run: |
           LOG_STRING="successfully installed in classpath"
-          echo "Stopping and removing existing container..."
-          docker stop $CONTAINER_NAME || true
-          docker rm $CONTAINER_NAME || true
-          
-          echo "Creating test network..."
-          docker network create --driver bridge test_network || echo "Network may already exist"
-          
-          echo "Starting container with docker run..."
-          echo "The log does not contain the string: $LOG_STRING"
-          exit 1
+          docker stop $CONTAINER_NAME
+          docker rm $CONTAINER_NAME
+          docker network create --driver bridge test_network
+          # Get the logs and check if the desired string is present
+          docker run -d --env LIQUIBASE_LICENSE_KEY=${{ secrets.PRO_LICENSE_KEY }} --name $CONTAINER_NAME --network test_network -v $(pwd)/.github/test:/liquibase/changelog liquibase/liquibase:${{ github.sha }} init start-h2
+          if docker exec $CONTAINER_NAME lpm add mssql --category=driver -g 2>&1 | grep -q "$LOG_STRING"; then
+              echo "The log contains the string: $LOG_STRING"
+          else
+              echo "The log does not contain the string: $LOG_STRING"
+              exit 1
           fi
 
       - name: Test custom entrypoint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,31 +158,55 @@ jobs:
         if: matrix.dockerfile != 'DockerfilePro'
         run: |
           LOG_STRING="liquibase-redshift"
+          echo "::group::Adding liquibase-redshift extension"
           # Stop docker container
           docker exec $CONTAINER_NAME lpm add liquibase-redshift --category=extension -g
+          echo "::endgroup::"
+          
+          echo "::group::Checking extension installation"
           # Get the logs and check if the desired string is present
+          docker exec $CONTAINER_NAME liquibase --version
           if docker exec $CONTAINER_NAME liquibase --version 2>&1 | grep -q "$LOG_STRING"; then
-              echo "The log contains the string: $LOG_STRING"
+          echo "The log contains the string: $LOG_STRING"
           else
-              echo "The log does not contain the string: $LOG_STRING"
-              exit 1
+          echo "The log does not contain the string: $LOG_STRING"
+          exit 1
           fi
+          echo "::endgroup::"
 
       - name: Test driver connection
         if: matrix.dockerfile != 'DockerfilePro'
         run: |
           LOG_STRING="successfully installed in classpath"
+          echo "::group::Container cleanup"
           echo "Stopping and removing existing container..."
           docker stop $CONTAINER_NAME || true
           docker rm $CONTAINER_NAME || true
+          echo "::endgroup::"
           
+          echo "::group::Network setup"
           echo "Creating test network..."
           docker network create --driver bridge test_network || echo "Network may already exist"
+          echo "::endgroup::"
           
+          echo "::group::Starting container"
           echo "Starting container with docker run..."
+          # Add docker run command with verbose output
+          docker run -d --network test_network --env LIQUIBASE_LICENSE_KEY=${{ secrets.PRO_LICENSE_KEY }} --name $CONTAINER_NAME -v $(pwd)/.github/test:/liquibase/changelog liquibase/liquibase:${{ github.sha }}
+          # Show container logs for debugging
+          echo "Container logs:"
+          docker logs $CONTAINER_NAME
+          echo "::endgroup::"
+          
+          echo "::group::Driver connection test"
+          # Test driver connection - add your actual test here
+          if docker exec $CONTAINER_NAME [your-command-here] 2>&1 | grep -q "$LOG_STRING"; then
+          echo "The log contains the string: $LOG_STRING"
+          else
           echo "The log does not contain the string: $LOG_STRING"
           exit 1
           fi
+          echo "::endgroup::"
 
       - name: Test custom entrypoint
         run: |


### PR DESCRIPTION
This pull request includes a conditional check to the `Test driver connection` step in the GitHub Actions workflow to exclude it for the `DockerfilePro` configuration.

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R172): Added a condition (`if: matrix.dockerfile != 'DockerfilePro'`) to the `Test driver connection` step to ensure it is skipped when the `DockerfilePro` configuration is used.