### PR TITLE
DAT-19929 test dockerhub

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -176,7 +176,7 @@ jobs:
             latest_tag: "alpine"
             type: liquibase-release
           - dockerfile: DockerfilePro
-            name: liquibase/liquibase-pro-test
+            name: liquibase/liquibase-pro
             suffix: ""
             latest_tag: "latest"
             type: liquibase-pro-release

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -176,7 +176,7 @@ jobs:
             latest_tag: "alpine"
             type: liquibase-release
           - dockerfile: DockerfilePro
-            name: liquibase/liquibase-pro
+            name: liquibase/liquibase-pro-test
             suffix: ""
             latest_tag: "latest"
             type: liquibase-pro-release
@@ -192,22 +192,22 @@ jobs:
           java-version: "8"
           distribution: "adopt"
 
-      # - name: Release Notes
-      #   if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && ((needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release') || (needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && matrix.type == 'liquibase-pro-release')) }}
-      #   uses: softprops/action-gh-release@v2
-      #   with:
-      #     name: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && format('v{0} PRO', needs.update-dockerfiles.outputs.extensionVersion) || format('v{0}', needs.update-dockerfiles.outputs.extensionVersion) }}
-      #     tag_name: v${{ needs.update-dockerfiles.outputs.extensionVersion }}
-      #     draft: true
-      #     body: |
-      #       ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && format('Support for Liquibase PRO {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) || format('Support for Liquibase {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) }}
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release Notes
+        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && ((needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release') || (needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && matrix.type == 'liquibase-pro-release')) }}
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && format('v{0} PRO', needs.update-dockerfiles.outputs.extensionVersion) || format('v{0}', needs.update-dockerfiles.outputs.extensionVersion) }}
+          tag_name: v${{ needs.update-dockerfiles.outputs.extensionVersion }}
+          draft: true
+          body: |
+            ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && format('Support for Liquibase PRO {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) || format('Support for Liquibase {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release' }}
+        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && ((needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release') || (needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && matrix.type == 'liquibase-pro-release')) }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/create-release.yml` file to re-enable and refine the release notes generation and Docker login steps in the GitHub Actions workflow. The changes ensure compatibility with both `liquibase-release` and `liquibase-pro-release` types.

### Workflow Updates:

* **Release Notes Step Re-enabled**: The previously commented-out `Release Notes` step has been reactivated. It now dynamically generates release notes for both `liquibase-release` and `liquibase-pro-release` types, using the `softprops/action-gh-release@v2` action. The step includes conditional logic and environment variable configurations for flexibility.

* **Docker Login Condition Updated**: The `docker/login-action@v3` step's condition was updated to handle both `liquibase-release` and `liquibase-pro-release` types, ensuring the step executes appropriately based on the release type.