### PR TITLE
Add GHCR Registry, add metadata labels, refactor login and tags logic

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -130,8 +130,10 @@ jobs:
           else
             file_list=("Dockerfile" "Dockerfile.alpine")
             LIQUIBASE_SHA=$(curl -LsS https://github.com/liquibase/liquibase/releases/download/v${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }')
-            LPM_SHA=$(curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip | sha256sum | awk '{ print $1 }')
-            LPM_SHA_ARM=$(curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux-arm64.zip | sha256sum | awk '{ print $1 }')
+            wget -q -O lpm-${{ env.LPM_VERSION }}-linux.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip"
+            wget -q -O lpm-${{ env.LPM_VERSION }}-linux-arm64.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux-arm64.zip"
+            LPM_SHA=$(lpm-${{ env.LPM_VERSION }}-linux.zip | sha256sum | awk '{ print $1 }')
+            LPM_SHA_ARM=$(lpm-${{ env.LPM_VERSION }}-linux-arm64.zip | sha256sum | awk '{ print $1 }')
             for file in "${file_list[@]}"; do
               sed -i 's/^ARG LIQUIBASE_VERSION=.*/ARG LIQUIBASE_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LB_SHA256=.*/ARG LB_SHA256='"$LIQUIBASE_SHA"'/' "${{ github.workspace }}/${file}"
@@ -305,81 +307,81 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           no-cache: true
-          push: true
+          push: false
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.generate-tags.outputs.tags }}
 
-  update-official-repo:
-    name: "Update Official Docker Repo"
-    needs: update-dockerfiles
-    if: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' }}
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-    steps:
-      - name: Extract major.minor version
-        id: extract_version
-        run: |
-          VERSION="${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
-          echo "MAJOR_MINOR=${VERSION%.*}" >> $GITHUB_ENV
-          echo "VERSION: $VERSION"
-          echo "MAJOR_MINOR: ${VERSION%.*}"
+  # update-official-repo:
+  #   name: "Update Official Docker Repo"
+  #   needs: update-dockerfiles
+  #   if: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' }}
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+  #   steps:
+  #     - name: Extract major.minor version
+  #       id: extract_version
+  #       run: |
+  #         VERSION="${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
+  #         echo "MAJOR_MINOR=${VERSION%.*}" >> $GITHUB_ENV
+  #         echo "VERSION: $VERSION"
+  #         echo "MAJOR_MINOR: ${VERSION%.*}"
 
-      - name: Check out liquibase/official-images
-        uses: actions/checkout@v4
-        with:
-          repository: liquibase/official-images
-          ref: master
-          token: ${{ env.GITHUB_TOKEN }}
+  #     - name: Check out liquibase/official-images
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: liquibase/official-images
+  #         ref: master
+  #         token: ${{ env.GITHUB_TOKEN }}
 
-      - name: Update library/liquibase in liquibase/official-images
-        run: |
-          echo "Maintainers: Jake Newton <docker@liquibase.com> (@jnewton03)" > library/liquibase
-          echo "Architectures: arm64v8, amd64" >> library/liquibase
-          echo "GitRepo: https://github.com/liquibase/docker.git" >> library/liquibase
-          echo "" >> library/liquibase
-          echo "Tags: ${{ env.MAJOR_MINOR }}, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}, latest" >> library/liquibase
-          echo "GitFetch: refs/heads/main" >> library/liquibase
-          echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
-          echo "File: Dockerfile" >> library/liquibase
-          echo "" >> library/liquibase
-          echo "Tags: ${{ env.MAJOR_MINOR }}-alpine, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}-alpine, alpine" >> library/liquibase
-          echo "GitFetch: refs/heads/main" >> library/liquibase
-          echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
-          echo "File: Dockerfile.alpine" >> library/liquibase
-          git add library/liquibase
-          if git diff-index --cached --quiet HEAD --
-            then
-              echo "Nothing new to commit"
-            else
-              git config user.name "liquibot"
-              git config user.email "liquibot@liquibase.org"
-              git commit -m "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
-              if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == false ]]; then
-                git push https://liquibot:$GITHUB_TOKEN@github.com/liquibase/official-images.git
-              else
-              echo "Dry run mode: changes have not been pushed."
-            fi
-          fi
+  #     - name: Update library/liquibase in liquibase/official-images
+  #       run: |
+  #         echo "Maintainers: Jake Newton <docker@liquibase.com> (@jnewton03)" > library/liquibase
+  #         echo "Architectures: arm64v8, amd64" >> library/liquibase
+  #         echo "GitRepo: https://github.com/liquibase/docker.git" >> library/liquibase
+  #         echo "" >> library/liquibase
+  #         echo "Tags: ${{ env.MAJOR_MINOR }}, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}, latest" >> library/liquibase
+  #         echo "GitFetch: refs/heads/main" >> library/liquibase
+  #         echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
+  #         echo "File: Dockerfile" >> library/liquibase
+  #         echo "" >> library/liquibase
+  #         echo "Tags: ${{ env.MAJOR_MINOR }}-alpine, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}-alpine, alpine" >> library/liquibase
+  #         echo "GitFetch: refs/heads/main" >> library/liquibase
+  #         echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
+  #         echo "File: Dockerfile.alpine" >> library/liquibase
+  #         git add library/liquibase
+  #         if git diff-index --cached --quiet HEAD --
+  #           then
+  #             echo "Nothing new to commit"
+  #           else
+  #             git config user.name "liquibot"
+  #             git config user.email "liquibot@liquibase.org"
+  #             git commit -m "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
+  #             if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == false ]]; then
+  #               git push https://liquibot:$GITHUB_TOKEN@github.com/liquibase/official-images.git
+  #             else
+  #             echo "Dry run mode: changes have not been pushed."
+  #           fi
+  #         fi
 
-      - name: Create Official Docker Pull Request
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-        id: create_pr
-        run: |
-          response=$(curl \
-            -X POST \
-            -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/docker-library/official-images/pulls \
-            -d '{
-              "title": "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}",
-              "body": "Update library/liquibase with latest commit and version",
-              "head": "liquibase:master",
-              "base": "master"
-            }')
-          pr_url=$(echo $response | jq -r '.html_url')
-          echo "PR_URL=$pr_url" >> $GITHUB_ENV
+  #     - name: Create Official Docker Pull Request
+  #       if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+  #       id: create_pr
+  #       run: |
+  #         response=$(curl \
+  #           -X POST \
+  #           -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
+  #           -H "Accept: application/vnd.github.v3+json" \
+  #           https://api.github.com/repos/docker-library/official-images/pulls \
+  #           -d '{
+  #             "title": "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}",
+  #             "body": "Update library/liquibase with latest commit and version",
+  #             "head": "liquibase:master",
+  #             "base": "master"
+  #           }')
+  #         pr_url=$(echo $response | jq -r '.html_url')
+  #         echo "PR_URL=$pr_url" >> $GITHUB_ENV
 
-      - name: Adding Official Docker PR to job summary
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-        run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY
+  #     - name: Adding Official Docker PR to job summary
+  #       if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+  #       run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -246,6 +246,17 @@ jobs:
           registry: public.ecr.aws
           username: ${{ secrets.PUBLIC_ECR_ACCESS_KEY_ID }}
           password: ${{ secrets.PUBLIC_ECR_SECRET_ACCESS_KEY }}
+          
+      # Add login for dry-run mode to private ECR
+      - name: Login to Private ECR Registry (dry-run)
+        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'true' }}
+        uses: docker/login-action@v3
+        env:
+          AWS_REGION: us-east-1
+        with:
+          registry: ${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}
+          username: ${{ secrets.PUBLIC_ECR_ACCESS_KEY_ID }}
+          password: ${{ secrets.PUBLIC_ECR_SECRET_ACCESS_KEY }}
 
       # Generate tags dynamically using a separate step
       - name: Generate Docker Tags

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   update-dockerfiles:
     env:
-      LPM_VERSION: "0.2.8"
+      LPM_VERSION: "0.2.9"
     name: "Update Dockerfiles"
     runs-on: ubuntu-latest
     outputs:
@@ -130,15 +130,13 @@ jobs:
           else
             file_list=("Dockerfile" "Dockerfile.alpine")
             LIQUIBASE_SHA=$(curl -LsS https://github.com/liquibase/liquibase/releases/download/v${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }')
-            wget -q -O lpm-${{ env.LPM_VERSION }}-linux.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip"
-            wget -q -O lpm-${{ env.LPM_VERSION }}-linux-arm64.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux-arm64.zip"
-            LPM_SHA=$(lpm-${{ env.LPM_VERSION }}-linux.zip | sha256sum | awk '{ print $1 }')
-            LPM_SHA_ARM=$(lpm-${{ env.LPM_VERSION }}-linux-arm64.zip | sha256sum | awk '{ print $1 }')
+            LPM_SHA=$(curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip | sha256sum | awk '{ print $1 }')
+            LPM_SHA_ARM=$(curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux-arm64.zip | sha256sum | awk '{ print $1 }')
             for file in "${file_list[@]}"; do
               sed -i 's/^ARG LIQUIBASE_VERSION=.*/ARG LIQUIBASE_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LB_SHA256=.*/ARG LB_SHA256='"$LIQUIBASE_SHA"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LPM_SHA256=.*/ARG LPM_SHA256='"$LPM_SHA"'/' "${{ github.workspace }}/${file}"
-              sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
+              #sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
               git add "${file}"
             done
             if git diff-index --cached --quiet HEAD --; then

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -246,7 +246,7 @@ jobs:
           registry: public.ecr.aws
           username: ${{ secrets.PUBLIC_ECR_ACCESS_KEY_ID }}
           password: ${{ secrets.PUBLIC_ECR_SECRET_ACCESS_KEY }}
-          
+
       # Add login for dry-run mode to private ECR
       - name: Login to Private ECR Registry (dry-run)
         if: ${{ needs.update-dockerfiles.outputs.dryRun == 'true' }}
@@ -267,38 +267,39 @@ jobs:
           SUFFIX="${{ matrix.suffix }}"
           LATEST_TAG="${{ matrix.latest_tag }}"
           TAGS=""
-          
+
           # Always add DockerHub tags
           TAGS="${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${LATEST_TAG}${SUFFIX}"
           TAGS="${TAGS},${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${VERSION}${SUFFIX}"
           TAGS="${TAGS},${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${MINOR_VERSION}${SUFFIX}"
-          
+
           # Add ECR tags if applicable
           if [[ -n "${{ steps.set-registries.outputs.ECR_REPO }}" ]]; then
             TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${LATEST_TAG}${SUFFIX}"
             TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${VERSION}${SUFFIX}"
             TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${MINOR_VERSION}${SUFFIX}"
           fi
-          
+
           # Add GHCR tags if applicable
           if [[ -n "${{ steps.set-registries.outputs.GHCR_REPO }}" ]]; then
             TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${LATEST_TAG}${SUFFIX}"
             TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${VERSION}${SUFFIX}"
             TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${MINOR_VERSION}${SUFFIX}"
           fi
-          
+
           # For dry run, only use ECR registry
           if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == "true" ]]; then
             TAGS="${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${LATEST_TAG}${SUFFIX}"
             TAGS="${TAGS},${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${VERSION}${SUFFIX}"
             TAGS="${TAGS},${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${MINOR_VERSION}${SUFFIX}"
           fi
-          
+
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "Generated tags: ${TAGS}"
 
       # Unified build and push step using generated tags
       - name: Build and Push Docker Image
+        if: ${{ needs.update-dockerfiles.outputs.releaseType == matrix.type }}
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -206,14 +206,39 @@ jobs:
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && ((needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release') || (needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && matrix.type == 'liquibase-pro-release')) }}
+
+      # Define registry configurations based on image type
+      - name: Set registry variables
+        id: set-registries
+        run: |
+          if [[ "${{ matrix.type }}" == "liquibase-release" ]]; then
+            echo "DOCKERHUB_REPO=${{ matrix.name }}" >> $GITHUB_OUTPUT
+            echo "ECR_REPO=public.ecr.aws/liquibase/liquibase" >> $GITHUB_OUTPUT
+            echo "GHCR_REPO=ghcr.io/liquibase/liquibase" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.type }}" == "liquibase-pro-release" ]]; then
+            echo "DOCKERHUB_REPO=${{ matrix.name }}" >> $GITHUB_OUTPUT
+            echo "ECR_REPO=" >> $GITHUB_OUTPUT
+            echo "GHCR_REPO=" >> $GITHUB_OUTPUT
+          fi
+
+      # Use separate login steps for each registry
+      - name: Login to Docker Hub
+        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && steps.set-registries.outputs.GHCR_REPO != '' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Login to ECR Registry
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release' }}
+        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && steps.set-registries.outputs.ECR_REPO != '' }}
         uses: docker/login-action@v3
         env:
           AWS_REGION: us-east-1
@@ -222,20 +247,47 @@ jobs:
           username: ${{ secrets.PUBLIC_ECR_ACCESS_KEY_ID }}
           password: ${{ secrets.PUBLIC_ECR_SECRET_ACCESS_KEY }}
 
-      - name: Login to ECR Private Registry (dry-run)
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'true' }}
-        uses: docker/login-action@v3
-        env:
-          AWS_REGION: us-east-1
-        with:
-          registry: ${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}
-          username: ${{ secrets.PUBLIC_ECR_ACCESS_KEY_ID }}
-          password: ${{ secrets.PUBLIC_ECR_SECRET_ACCESS_KEY }}
+      # Generate tags dynamically using a separate step
+      - name: Generate Docker Tags
+        id: generate-tags
+        run: |
+          VERSION="${{ needs.update-dockerfiles.outputs.extensionVersion }}"
+          MINOR_VERSION="${{ needs.update-dockerfiles.outputs.minorVersion }}"
+          SUFFIX="${{ matrix.suffix }}"
+          LATEST_TAG="${{ matrix.latest_tag }}"
+          TAGS=""
+          
+          # Always add DockerHub tags
+          TAGS="${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${LATEST_TAG}${SUFFIX}"
+          TAGS="${TAGS},${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${VERSION}${SUFFIX}"
+          TAGS="${TAGS},${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${MINOR_VERSION}${SUFFIX}"
+          
+          # Add ECR tags if applicable
+          if [[ -n "${{ steps.set-registries.outputs.ECR_REPO }}" ]]; then
+            TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${LATEST_TAG}${SUFFIX}"
+            TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${VERSION}${SUFFIX}"
+            TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${MINOR_VERSION}${SUFFIX}"
+          fi
+          
+          # Add GHCR tags if applicable
+          if [[ -n "${{ steps.set-registries.outputs.GHCR_REPO }}" ]]; then
+            TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${LATEST_TAG}${SUFFIX}"
+            TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${VERSION}${SUFFIX}"
+            TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${MINOR_VERSION}${SUFFIX}"
+          fi
+          
+          # For dry run, only use ECR registry
+          if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == "true" ]]; then
+            TAGS="${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${LATEST_TAG}${SUFFIX}"
+            TAGS="${TAGS},${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${VERSION}${SUFFIX}"
+            TAGS="${TAGS},${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${MINOR_VERSION}${SUFFIX}"
+          fi
+          
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "Generated tags: ${TAGS}"
 
+      # Unified build and push step using generated tags
       - name: Build and Push Docker Image
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && ((needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release') || (needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && matrix.type == 'liquibase-pro-release')) }}
-        env:
-          ECR_REGISTRY: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && 'public.ecr.aws/liquibase/liquibase' || '' }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -243,22 +295,7 @@ jobs:
           no-cache: true
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ matrix.name }}:${{ matrix.latest_tag }}${{ matrix.suffix }}${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && format(',{0}:{1}{2},{0}:{3}{2},{4}:{1}{2},{4}:{3}{2}', matrix.name, needs.update-dockerfiles.outputs.extensionVersion, matrix.suffix, needs.update-dockerfiles.outputs.minorVersion, env.ECR_REGISTRY) || format(',{0}:{1}{2},{0}:{3}{2}', matrix.name, needs.update-dockerfiles.outputs.liquibaseVersion, matrix.suffix, needs.update-dockerfiles.outputs.minorVersion) }}
-
-      - name: Build and Push Docker Image (dry-run)
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'true' && ((needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release') || (needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && matrix.type == 'liquibase-pro-release')) }}
-        env:
-          ECR_REGISTRY: ${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          no-cache: true
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.ECR_REGISTRY }}:${{ matrix.latest_tag }}${{ matrix.suffix }},${{ env.ECR_REGISTRY }}:${{ needs.update-dockerfiles.outputs.extensionVersion }}${{ matrix.suffix }},${{ env.ECR_REGISTRY }}:${{ needs.update-dockerfiles.outputs.minorVersion }}${{ matrix.suffix }}
+          tags: ${{ steps.generate-tags.outputs.tags }}
 
   update-official-repo:
     name: "Update Official Docker Repo"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -305,81 +305,81 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           no-cache: true
-          push: false
+          push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.generate-tags.outputs.tags }}
 
-  # update-official-repo:
-  #   name: "Update Official Docker Repo"
-  #   needs: update-dockerfiles
-  #   if: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' }}
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-  #   steps:
-  #     - name: Extract major.minor version
-  #       id: extract_version
-  #       run: |
-  #         VERSION="${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
-  #         echo "MAJOR_MINOR=${VERSION%.*}" >> $GITHUB_ENV
-  #         echo "VERSION: $VERSION"
-  #         echo "MAJOR_MINOR: ${VERSION%.*}"
+  update-official-repo:
+    name: "Update Official Docker Repo"
+    needs: update-dockerfiles
+    if: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' }}
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+    steps:
+      - name: Extract major.minor version
+        id: extract_version
+        run: |
+          VERSION="${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
+          echo "MAJOR_MINOR=${VERSION%.*}" >> $GITHUB_ENV
+          echo "VERSION: $VERSION"
+          echo "MAJOR_MINOR: ${VERSION%.*}"
 
-  #     - name: Check out liquibase/official-images
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: liquibase/official-images
-  #         ref: master
-  #         token: ${{ env.GITHUB_TOKEN }}
+      - name: Check out liquibase/official-images
+        uses: actions/checkout@v4
+        with:
+          repository: liquibase/official-images
+          ref: master
+          token: ${{ env.GITHUB_TOKEN }}
 
-  #     - name: Update library/liquibase in liquibase/official-images
-  #       run: |
-  #         echo "Maintainers: Jake Newton <docker@liquibase.com> (@jnewton03)" > library/liquibase
-  #         echo "Architectures: arm64v8, amd64" >> library/liquibase
-  #         echo "GitRepo: https://github.com/liquibase/docker.git" >> library/liquibase
-  #         echo "" >> library/liquibase
-  #         echo "Tags: ${{ env.MAJOR_MINOR }}, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}, latest" >> library/liquibase
-  #         echo "GitFetch: refs/heads/main" >> library/liquibase
-  #         echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
-  #         echo "File: Dockerfile" >> library/liquibase
-  #         echo "" >> library/liquibase
-  #         echo "Tags: ${{ env.MAJOR_MINOR }}-alpine, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}-alpine, alpine" >> library/liquibase
-  #         echo "GitFetch: refs/heads/main" >> library/liquibase
-  #         echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
-  #         echo "File: Dockerfile.alpine" >> library/liquibase
-  #         git add library/liquibase
-  #         if git diff-index --cached --quiet HEAD --
-  #           then
-  #             echo "Nothing new to commit"
-  #           else
-  #             git config user.name "liquibot"
-  #             git config user.email "liquibot@liquibase.org"
-  #             git commit -m "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
-  #             if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == false ]]; then
-  #               git push https://liquibot:$GITHUB_TOKEN@github.com/liquibase/official-images.git
-  #             else
-  #             echo "Dry run mode: changes have not been pushed."
-  #           fi
-  #         fi
+      - name: Update library/liquibase in liquibase/official-images
+        run: |
+          echo "Maintainers: Jake Newton <docker@liquibase.com> (@jnewton03)" > library/liquibase
+          echo "Architectures: arm64v8, amd64" >> library/liquibase
+          echo "GitRepo: https://github.com/liquibase/docker.git" >> library/liquibase
+          echo "" >> library/liquibase
+          echo "Tags: ${{ env.MAJOR_MINOR }}, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}, latest" >> library/liquibase
+          echo "GitFetch: refs/heads/main" >> library/liquibase
+          echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
+          echo "File: Dockerfile" >> library/liquibase
+          echo "" >> library/liquibase
+          echo "Tags: ${{ env.MAJOR_MINOR }}-alpine, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}-alpine, alpine" >> library/liquibase
+          echo "GitFetch: refs/heads/main" >> library/liquibase
+          echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
+          echo "File: Dockerfile.alpine" >> library/liquibase
+          git add library/liquibase
+          if git diff-index --cached --quiet HEAD --
+            then
+              echo "Nothing new to commit"
+            else
+              git config user.name "liquibot"
+              git config user.email "liquibot@liquibase.org"
+              git commit -m "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
+              if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == false ]]; then
+                git push https://liquibot:$GITHUB_TOKEN@github.com/liquibase/official-images.git
+              else
+              echo "Dry run mode: changes have not been pushed."
+            fi
+          fi
 
-  #     - name: Create Official Docker Pull Request
-  #       if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-  #       id: create_pr
-  #       run: |
-  #         response=$(curl \
-  #           -X POST \
-  #           -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
-  #           -H "Accept: application/vnd.github.v3+json" \
-  #           https://api.github.com/repos/docker-library/official-images/pulls \
-  #           -d '{
-  #             "title": "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}",
-  #             "body": "Update library/liquibase with latest commit and version",
-  #             "head": "liquibase:master",
-  #             "base": "master"
-  #           }')
-  #         pr_url=$(echo $response | jq -r '.html_url')
-  #         echo "PR_URL=$pr_url" >> $GITHUB_ENV
+      - name: Create Official Docker Pull Request
+        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+        id: create_pr
+        run: |
+          response=$(curl \
+            -X POST \
+            -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/docker-library/official-images/pulls \
+            -d '{
+              "title": "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}",
+              "body": "Update library/liquibase with latest commit and version",
+              "head": "liquibase:master",
+              "base": "master"
+            }')
+          pr_url=$(echo $response | jq -r '.html_url')
+          echo "PR_URL=$pr_url" >> $GITHUB_ENV
 
-  #     - name: Adding Official Docker PR to job summary
-  #       if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-  #       run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY
+      - name: Adding Official Docker PR to job summary
+        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+        run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -138,7 +138,7 @@ jobs:
               sed -i 's/^ARG LIQUIBASE_VERSION=.*/ARG LIQUIBASE_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LB_SHA256=.*/ARG LB_SHA256='"$LIQUIBASE_SHA"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LPM_SHA256=.*/ARG LPM_SHA256='"$LPM_SHA"'/' "${{ github.workspace }}/${file}"
-              #sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
+              sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
               git add "${file}"
             done
             if git diff-index --cached --quiet HEAD --; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquiba
     liquibase --version
 
 ARG LPM_VERSION=0.2.9
-ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
+ARG LPM_SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
 
 # Download and Install lpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 # Builder Stage
 FROM eclipse-temurin:21-jre-jammy
 
+ARG LIQUIBASE_VERSION=4.31.1
+ARG LB_SHA256=0555808b59941d497f0c1114c3f2225698afde11c60d191c88e449506a60a3ea
+ARG LPM_VERSION=0.2.9
+ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
+ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
+
 # Create liquibase user
 RUN groupadd --gid 1001 liquibase && \
     useradd --uid 1001 --gid liquibase --create-home --home-dir /liquibase liquibase && \
@@ -17,9 +23,6 @@ LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"
 # Download and install Liquibase
 WORKDIR /liquibase
 
-ARG LIQUIBASE_VERSION=4.31.1
-ARG LB_SHA256=0555808b59941d497f0c1114c3f2225698afde11c60d191c88e449506a60a3ea
-
 RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" && \
     echo "$LB_SHA256 *liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - && \
     tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz && \
@@ -28,10 +31,6 @@ RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquiba
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
 
-ARG LPM_VERSION=0.2.9
-ARG LPM_SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
-
 # Download and Install lpm
 RUN apt-get update && \
     apt-get -yqq install unzip --no-install-recommends && \
@@ -39,9 +38,9 @@ RUN apt-get update && \
     mkdir /liquibase/bin && \
     arch="$(dpkg --print-architecture)" && \
     case "$arch" in \
-      amd64)  DOWNLOAD_ARCH=""  ;; \
-      arm64)  DOWNLOAD_ARCH="-arm64" && LPM_SHA256=$LPM_SHA256_ARM ;; \
-      *) echo >&2 "error: unsupported architecture '$arch'" && exit 1 ;; \
+    amd64)  DOWNLOAD_ARCH=""  ;; \
+    arm64)  DOWNLOAD_ARCH="-arm64" && LPM_SHA256=$LPM_SHA256_ARM ;; \
+    *) echo >&2 "error: unsupported architecture '$arch'" && exit 1 ;; \
     esac && wget -q -O lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${LPM_VERSION}/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" && \
     echo "$LPM_SHA256 *lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" | sha256sum -c - && \
     unzip lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip -d bin/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,13 @@ RUN groupadd --gid 1001 liquibase && \
     useradd --uid 1001 --gid liquibase --create-home --home-dir /liquibase liquibase && \
     chown liquibase /liquibase
 
-# Install necessary dependencies
-#RUN apt-get update && \
-#    apt-get -yqq install krb5-user libpam-krb5 --no-install-recommends && \
-#    rm -rf /var/lib/apt/lists/*
+# Add metadata labels
+LABEL org.opencontainers.image.source="https://github.com/liquibase/docker"
+LABEL org.opencontainers.image.description="Liquibase Container Image"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="Liquibase"
+LABEL org.opencontainers.image.version="${LIQUIBASE_VERSION}"
+LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"
 
 # Download and install Liquibase
 WORKDIR /liquibase

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,6 +9,14 @@ RUN addgroup --gid 1001 liquibase && \
 # Install smaller JRE, if available and acceptable
 RUN apk add --no-cache openjdk21-jre-headless bash
 
+# Add metadata labels
+LABEL org.opencontainers.image.source="https://github.com/liquibase/docker"
+LABEL org.opencontainers.image.description="Liquibase Container Image (Alpine)"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="Liquibase"
+LABEL org.opencontainers.image.version="${LIQUIBASE_VERSION}"
+LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"
+
 WORKDIR /liquibase
 
 ARG LIQUIBASE_VERSION=4.31.1

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -35,7 +35,7 @@ RUN set -x && \
     liquibase --version
 
 ARG LPM_VERSION=0.2.9
-ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
+ARG LPM_SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
 
 # Download and Install lpm

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,12 @@
 # Use multi-stage build
 FROM alpine:3.21
 
+ARG LIQUIBASE_VERSION=4.31.1
+ARG LB_SHA256=0555808b59941d497f0c1114c3f2225698afde11c60d191c88e449506a60a3ea
+ARG LPM_VERSION=0.2.9
+ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
+ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
+
 # Create liquibase user
 RUN addgroup --gid 1001 liquibase && \
     adduser --disabled-password --uid 1001 --ingroup liquibase --home /liquibase liquibase && \
@@ -19,9 +25,6 @@ LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"
 
 WORKDIR /liquibase
 
-ARG LIQUIBASE_VERSION=4.31.1
-ARG LB_SHA256=0555808b59941d497f0c1114c3f2225698afde11c60d191c88e449506a60a3ea
-
 # Download, verify, extract
 RUN set -x && \
     apk add --no-cache --virtual .fetch-deps wget && \
@@ -33,10 +36,6 @@ RUN set -x && \
     ln -s /liquibase/liquibase /usr/local/bin/liquibase && \
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
-
-ARG LPM_VERSION=0.2.9
-ARG LPM_SHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
 
 # Download and Install lpm
 RUN mkdir /liquibase/bin && \


### PR DESCRIPTION
Addresses first step in request from https://github.com/liquibase/github-action-generator/issues/151

This pull request introduces significant updates to the Docker build and release workflows, as well as enhancements to the Dockerfiles for better metadata and maintainability. The changes focus on improving registry handling, dynamic tag generation, and adding metadata labels to the Docker images.

### Workflow Improvements
* Refactored `.github/workflows/create-release.yml` to replace hardcoded registry logic with dynamic registry configuration using a new `Set registry variables` step. This allows for more flexible handling of DockerHub, ECR, and GHCR registries.
* Introduced a `Generate Docker Tags` step to dynamically construct image tags based on release type, version, and suffix, consolidating tag generation logic into a single step.
* Unified the build and push process into a single step that utilizes dynamically generated tags, simplifying the workflow and reducing redundancy.

### Dockerfile Enhancements
* Added Open Container Initiative (OCI) metadata labels in `Dockerfile` to provide descriptive information about the image, such as source repository, version, license, and documentation.
* Added similar OCI metadata labels in `Dockerfile.alpine` for the Alpine-based Liquibase image, ensuring consistency across all image variants.