### PR TITLE
DAT-20120 Enhance create-release workflow: add options for Docker Hub, GHCR, and ECR publishing

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,6 +28,18 @@ on:
         required: false
         type: string
         default: ""
+      pushDockerHub:
+        description: "Publish to Docker Hub"
+        type: boolean
+        default: true
+      pushGHCR:
+        description: "Publish to GitHub Container Registry"
+        type: boolean
+        default: true
+      pushECR:
+        description: "Publish to AWS Public ECR"
+        type: boolean
+        default: true
 
 jobs:
   update-dockerfiles:
@@ -42,6 +54,9 @@ jobs:
       dryRun: ${{ steps.collect-data.outputs.dryRun }}
       minorVersion: ${{ steps.collect-data.outputs.minorVersion }}
       latestCommitSha: ${{ steps.get-latest-sha.outputs.latestCommitSha }}
+      pushDockerHub: ${{ steps.collect-data.outputs.pushDockerHub }}
+      pushGHCR: ${{ steps.collect-data.outputs.pushGHCR }}
+      pushECR: ${{ steps.collect-data.outputs.pushECR }}
 
     steps:
       - name: Collect Data
@@ -68,6 +83,9 @@ jobs:
               core.setOutput("minorVersion", minorVersion);
               core.setOutput("dryRun", dryRun);
               core.setOutput("releaseType", eventType);
+              core.setOutput("pushDockerHub", 'true');
+              core.setOutput("pushGHCR", 'true');
+              core.setOutput("pushECR", 'true');
             } else if (context.payload.inputs) {
               eventType = context.payload.inputs.releaseType || 'liquibase-release';
               liquibaseVersion = context.payload.inputs.liquibaseVersion;
@@ -78,6 +96,9 @@ jobs:
               core.setOutput("minorVersion", minorVersion);
               core.setOutput("dryRun", dryRun);
               core.setOutput("releaseType", eventType);
+              core.setOutput("pushDockerHub", (context.payload.inputs?.pushDockerHub ?? 'true'));
+              core.setOutput("pushGHCR", (context.payload.inputs?.pushGHCR ?? 'true'));
+              core.setOutput("pushECR", (context.payload.inputs?.pushECR ?? 'true'));
             } else {
               core.setFailed('Unknown event type');
             }
@@ -162,6 +183,10 @@ jobs:
     name: "Build and Push Docker Images"
     needs: update-dockerfiles
     runs-on: ubuntu-latest
+    env:
+      PUSH_DOCKERHUB: ${{ needs.update-dockerfiles.outputs.pushDockerHub }}
+      PUSH_GHCR: ${{ needs.update-dockerfiles.outputs.pushGHCR }}
+      PUSH_ECR: ${{ needs.update-dockerfiles.outputs.pushECR }}
     strategy:
       matrix:
         include:
@@ -223,14 +248,14 @@ jobs:
 
       # Use separate login steps for each registry
       - name: Login to Docker Hub
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+        if: ${{ env.PUSH_DOCKERHUB == 'true' && needs.update-dockerfiles.outputs.dryRun == 'false' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && steps.set-registries.outputs.GHCR_REPO != '' }}
+        if: ${{ env.PUSH_GHCR == 'true' && needs.update-dockerfiles.outputs.dryRun == 'false' && steps.set-registries.outputs.GHCR_REPO != '' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -238,7 +263,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to ECR Registry
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && steps.set-registries.outputs.ECR_REPO != '' }}
+        if: ${{ env.PUSH_ECR == 'true' && needs.update-dockerfiles.outputs.dryRun == 'false' && steps.set-registries.outputs.ECR_REPO != '' }}
         uses: docker/login-action@v3
         env:
           AWS_REGION: us-east-1
@@ -268,30 +293,42 @@ jobs:
           LATEST_TAG="${{ matrix.latest_tag }}"
           TAGS=""
 
-          # Always add DockerHub tags
-          TAGS="${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${LATEST_TAG}${SUFFIX}"
-          TAGS="${TAGS},${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${VERSION}${SUFFIX}"
-          TAGS="${TAGS},${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${MINOR_VERSION}${SUFFIX}"
-
-          # Add ECR tags if applicable
-          if [[ -n "${{ steps.set-registries.outputs.ECR_REPO }}" ]]; then
-            TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${LATEST_TAG}${SUFFIX}"
-            TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${VERSION}${SUFFIX}"
-            TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${MINOR_VERSION}${SUFFIX}"
-          fi
-
-          # Add GHCR tags if applicable
-          if [[ -n "${{ steps.set-registries.outputs.GHCR_REPO }}" ]]; then
-            TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${LATEST_TAG}${SUFFIX}"
-            TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${VERSION}${SUFFIX}"
-            TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${MINOR_VERSION}${SUFFIX}"
-          fi
-
           # For dry run, only use ECR registry
           if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == "true" ]]; then
             TAGS="${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${LATEST_TAG}${SUFFIX}"
             TAGS="${TAGS},${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${VERSION}${SUFFIX}"
             TAGS="${TAGS},${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${MINOR_VERSION}${SUFFIX}"
+            echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+            echo "Generated tags (dry-run): ${TAGS}"
+            exit 0
+          fi
+          
+          # Add DockerHub tags if selected
+          if [[ "${PUSH_DOCKERHUB}" == "true" ]]; then
+            TAGS="${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${LATEST_TAG}${SUFFIX}"
+            TAGS="${TAGS},${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${VERSION}${SUFFIX}"
+            TAGS="${TAGS},${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${MINOR_VERSION}${SUFFIX}"
+          fi
+
+          # Add ECR tags if selected and available for this image type
+          if [[ "${PUSH_ECR}" == "true" && -n "${{ steps.set-registries.outputs.ECR_REPO }}" ]]; then
+            if [[ -n "${TAGS}" ]]; then TAGS="${TAGS},"; fi
+            TAGS="${TAGS}${{ steps.set-registries.outputs.ECR_REPO }}:${LATEST_TAG}${SUFFIX}"
+            TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${VERSION}${SUFFIX}"
+            TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${MINOR_VERSION}${SUFFIX}"
+          fi
+
+          # Add GHCR tags if selected and available for this image type
+          if [[ "${PUSH_GHCR}" == "true" && -n "${{ steps.set-registries.outputs.GHCR_REPO }}" ]]; then
+            if [[ -n "${TAGS}" ]]; then TAGS="${TAGS},"; fi
+            TAGS="${TAGS}${{ steps.set-registries.outputs.GHCR_REPO }}:${LATEST_TAG}${SUFFIX}"
+            TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${VERSION}${SUFFIX}"
+            TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${MINOR_VERSION}${SUFFIX}"
+          fi
+
+          if [[ -z "${TAGS}" ]]; then
+            echo "::warning::No registries were selected. Running in dry-run mode."
+            TAGS="${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${LATEST_TAG}${SUFFIX}"
           fi
 
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -351,6 +351,22 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.generate-tags.outputs.tags }}
+          # Labels applied to each architecture-specific image
+          labels: |
+            org.opencontainers.image.source=https://github.com/liquibase/docker
+            org.opencontainers.image.description=${{ matrix.type == 'liquibase-pro-release' && 'Liquibase PRO Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=Liquibase
+            org.opencontainers.image.version=${{ needs.update-dockerfiles.outputs.extensionVersion }}
+            org.opencontainers.image.documentation=https://docs.liquibase.com
+          # Annotations applied to the manifest list (important for multi-arch images)
+          annotations: |
+            org.opencontainers.image.source=https://github.com/liquibase/docker
+            org.opencontainers.image.description=${{ matrix.type == 'liquibase-pro-release' && 'Liquibase PRO Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=Liquibase
+            org.opencontainers.image.version=${{ needs.update-dockerfiles.outputs.extensionVersion }}
+            org.opencontainers.image.documentation=https://docs.liquibase.com
 
   update-official-repo:
     name: "Update Official Docker Repo"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -306,7 +306,6 @@ jobs:
             TAGS="${TAGS},${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${MINOR_VERSION}${SUFFIX}"
             echo "tags=${TAGS}" >> $GITHUB_OUTPUT
             echo "Generated tags (dry-run): ${TAGS}"
-            exit 0
           fi
           
           # Add DockerHub tags if selected

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -298,46 +298,53 @@ jobs:
           SUFFIX="${{ matrix.suffix }}"
           LATEST_TAG="${{ matrix.latest_tag }}"
           TAGS=""
+          IS_DRY_RUN="${{ needs.update-dockerfiles.outputs.dryRun }}"
 
-          # For dry run, only use ECR registry
-          if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == "true" ]]; then
+          if [[ "${IS_DRY_RUN}" == "true" ]]; then
+            # For dry run, only use ECR registry
             TAGS="${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${LATEST_TAG}${SUFFIX}"
             TAGS="${TAGS},${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${VERSION}${SUFFIX}"
             TAGS="${TAGS},${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${MINOR_VERSION}${SUFFIX}"
-            echo "tags=${TAGS}" >> $GITHUB_OUTPUT
-            echo "Generated tags (dry-run): ${TAGS}"
-          fi
-          
-          # Add DockerHub tags if selected
-          if [[ "${PUSH_DOCKERHUB}" == "true" ]]; then
-            TAGS="${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${LATEST_TAG}${SUFFIX}"
-            TAGS="${TAGS},${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${VERSION}${SUFFIX}"
-            TAGS="${TAGS},${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${MINOR_VERSION}${SUFFIX}"
+          else
+            # Not in dry-run mode, apply normal tag selection logic
+            
+            # Add DockerHub tags if selected
+            if [[ "${PUSH_DOCKERHUB}" == "true" ]]; then
+              TAGS="${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${LATEST_TAG}${SUFFIX}"
+              TAGS="${TAGS},${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${VERSION}${SUFFIX}"
+              TAGS="${TAGS},${{ steps.set-registries.outputs.DOCKERHUB_REPO }}:${MINOR_VERSION}${SUFFIX}"
+            fi
+
+            # Add ECR tags if selected and available for this image type
+            if [[ "${PUSH_ECR}" == "true" && -n "${{ steps.set-registries.outputs.ECR_REPO }}" ]]; then
+              if [[ -n "${TAGS}" ]]; then TAGS="${TAGS},"; fi
+              TAGS="${TAGS}${{ steps.set-registries.outputs.ECR_REPO }}:${LATEST_TAG}${SUFFIX}"
+              TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${VERSION}${SUFFIX}"
+              TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${MINOR_VERSION}${SUFFIX}"
+            fi
+
+            # Add GHCR tags if selected and available for this image type
+            if [[ "${PUSH_GHCR}" == "true" && -n "${{ steps.set-registries.outputs.GHCR_REPO }}" ]]; then
+              if [[ -n "${TAGS}" ]]; then TAGS="${TAGS},"; fi
+              TAGS="${TAGS}${{ steps.set-registries.outputs.GHCR_REPO }}:${LATEST_TAG}${SUFFIX}"
+              TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${VERSION}${SUFFIX}"
+              TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${MINOR_VERSION}${SUFFIX}"
+            fi
+
+            # If no tags were set, fall back to dry-run mode
+            if [[ -z "${TAGS}" ]]; then
+              echo "::warning::No registries were selected. Running in dry-run mode."
+              TAGS="${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${LATEST_TAG}${SUFFIX}"
+            fi
           fi
 
-          # Add ECR tags if selected and available for this image type
-          if [[ "${PUSH_ECR}" == "true" && -n "${{ steps.set-registries.outputs.ECR_REPO }}" ]]; then
-            if [[ -n "${TAGS}" ]]; then TAGS="${TAGS},"; fi
-            TAGS="${TAGS}${{ steps.set-registries.outputs.ECR_REPO }}:${LATEST_TAG}${SUFFIX}"
-            TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${VERSION}${SUFFIX}"
-            TAGS="${TAGS},${{ steps.set-registries.outputs.ECR_REPO }}:${MINOR_VERSION}${SUFFIX}"
-          fi
-
-          # Add GHCR tags if selected and available for this image type
-          if [[ "${PUSH_GHCR}" == "true" && -n "${{ steps.set-registries.outputs.GHCR_REPO }}" ]]; then
-            if [[ -n "${TAGS}" ]]; then TAGS="${TAGS},"; fi
-            TAGS="${TAGS}${{ steps.set-registries.outputs.GHCR_REPO }}:${LATEST_TAG}${SUFFIX}"
-            TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${VERSION}${SUFFIX}"
-            TAGS="${TAGS},${{ steps.set-registries.outputs.GHCR_REPO }}:${MINOR_VERSION}${SUFFIX}"
-          fi
-
-          if [[ -z "${TAGS}" ]]; then
-            echo "::warning::No registries were selected. Running in dry-run mode."
-            TAGS="${{ secrets.PRIVATE_ECR_DRY_RUN_REPO }}:${LATEST_TAG}${SUFFIX}"
-          fi
-
+          # Output tags at the end
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
-          echo "Generated tags: ${TAGS}"
+          if [[ "${IS_DRY_RUN}" == "true" ]]; then
+            echo "Generated tags (dry-run): ${TAGS}"
+          else
+            echo "Generated tags: ${TAGS}"
+          fi
 
       # Unified build and push step using generated tags
       - name: Build and Push Docker Image

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -346,77 +346,77 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.generate-tags.outputs.tags }}
 
-  # update-official-repo:
-  #   name: "Update Official Docker Repo"
-  #   needs: update-dockerfiles
-  #   if: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' }}
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-  #   steps:
-  #     - name: Extract major.minor version
-  #       id: extract_version
-  #       run: |
-  #         VERSION="${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
-  #         echo "MAJOR_MINOR=${VERSION%.*}" >> $GITHUB_ENV
-  #         echo "VERSION: $VERSION"
-  #         echo "MAJOR_MINOR: ${VERSION%.*}"
+  update-official-repo:
+    name: "Update Official Docker Repo"
+    needs: update-dockerfiles
+    if: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' }}
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+    steps:
+      - name: Extract major.minor version
+        id: extract_version
+        run: |
+          VERSION="${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
+          echo "MAJOR_MINOR=${VERSION%.*}" >> $GITHUB_ENV
+          echo "VERSION: $VERSION"
+          echo "MAJOR_MINOR: ${VERSION%.*}"
 
-  #     - name: Check out liquibase/official-images
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: liquibase/official-images
-  #         ref: master
-  #         token: ${{ env.GITHUB_TOKEN }}
+      - name: Check out liquibase/official-images
+        uses: actions/checkout@v4
+        with:
+          repository: liquibase/official-images
+          ref: master
+          token: ${{ env.GITHUB_TOKEN }}
 
-  #     - name: Update library/liquibase in liquibase/official-images
-  #       run: |
-  #         echo "Maintainers: Jake Newton <docker@liquibase.com> (@jnewton03)" > library/liquibase
-  #         echo "Architectures: arm64v8, amd64" >> library/liquibase
-  #         echo "GitRepo: https://github.com/liquibase/docker.git" >> library/liquibase
-  #         echo "" >> library/liquibase
-  #         echo "Tags: ${{ env.MAJOR_MINOR }}, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}, latest" >> library/liquibase
-  #         echo "GitFetch: refs/heads/main" >> library/liquibase
-  #         echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
-  #         echo "File: Dockerfile" >> library/liquibase
-  #         echo "" >> library/liquibase
-  #         echo "Tags: ${{ env.MAJOR_MINOR }}-alpine, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}-alpine, alpine" >> library/liquibase
-  #         echo "GitFetch: refs/heads/main" >> library/liquibase
-  #         echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
-  #         echo "File: Dockerfile.alpine" >> library/liquibase
-  #         git add library/liquibase
-  #         if git diff-index --cached --quiet HEAD --
-  #           then
-  #             echo "Nothing new to commit"
-  #           else
-  #             git config user.name "liquibot"
-  #             git config user.email "liquibot@liquibase.org"
-  #             git commit -m "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
-  #             if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == false ]]; then
-  #               git push https://liquibot:$GITHUB_TOKEN@github.com/liquibase/official-images.git
-  #             else
-  #             echo "Dry run mode: changes have not been pushed."
-  #           fi
-  #         fi
+      - name: Update library/liquibase in liquibase/official-images
+        run: |
+          echo "Maintainers: Jake Newton <docker@liquibase.com> (@jnewton03)" > library/liquibase
+          echo "Architectures: arm64v8, amd64" >> library/liquibase
+          echo "GitRepo: https://github.com/liquibase/docker.git" >> library/liquibase
+          echo "" >> library/liquibase
+          echo "Tags: ${{ env.MAJOR_MINOR }}, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}, latest" >> library/liquibase
+          echo "GitFetch: refs/heads/main" >> library/liquibase
+          echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
+          echo "File: Dockerfile" >> library/liquibase
+          echo "" >> library/liquibase
+          echo "Tags: ${{ env.MAJOR_MINOR }}-alpine, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}-alpine, alpine" >> library/liquibase
+          echo "GitFetch: refs/heads/main" >> library/liquibase
+          echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
+          echo "File: Dockerfile.alpine" >> library/liquibase
+          git add library/liquibase
+          if git diff-index --cached --quiet HEAD --
+            then
+              echo "Nothing new to commit"
+            else
+              git config user.name "liquibot"
+              git config user.email "liquibot@liquibase.org"
+              git commit -m "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
+              if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == false ]]; then
+                git push https://liquibot:$GITHUB_TOKEN@github.com/liquibase/official-images.git
+              else
+              echo "Dry run mode: changes have not been pushed."
+            fi
+          fi
 
-  #     - name: Create Official Docker Pull Request
-  #       if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-  #       id: create_pr
-  #       run: |
-  #         response=$(curl \
-  #           -X POST \
-  #           -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
-  #           -H "Accept: application/vnd.github.v3+json" \
-  #           https://api.github.com/repos/docker-library/official-images/pulls \
-  #           -d '{
-  #             "title": "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}",
-  #             "body": "Update library/liquibase with latest commit and version",
-  #             "head": "liquibase:master",
-  #             "base": "master"
-  #           }')
-  #         pr_url=$(echo $response | jq -r '.html_url')
-  #         echo "PR_URL=$pr_url" >> $GITHUB_ENV
+      - name: Create Official Docker Pull Request
+        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+        id: create_pr
+        run: |
+          response=$(curl \
+            -X POST \
+            -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/docker-library/official-images/pulls \
+            -d '{
+              "title": "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}",
+              "body": "Update library/liquibase with latest commit and version",
+              "head": "liquibase:master",
+              "base": "master"
+            }')
+          pr_url=$(echo $response | jq -r '.html_url')
+          echo "PR_URL=$pr_url" >> $GITHUB_ENV
 
-  #     - name: Adding Official Docker PR to job summary
-  #       if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-  #       run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY
+      - name: Adding Official Docker PR to job summary
+        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+        run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -102,9 +102,9 @@ jobs:
               core.setOutput("minorVersion", minorVersion);
               core.setOutput("dryRun", dryRun);
               core.setOutput("releaseType", eventType);
-              core.setOutput("pushDockerHub", (context.payload.inputs?.pushDockerHub ?? 'true'));
-              core.setOutput("pushGHCR", (context.payload.inputs?.pushGHCR ?? 'true'));
-              core.setOutput("pushECR", (context.payload.inputs?.pushECR ?? 'true'));
+              core.setOutput("pushDockerHub", Boolean(context.payload.inputs?.pushDockerHub ?? true));
+              core.setOutput("pushGHCR", Boolean(context.payload.inputs?.pushGHCR ?? true));
+              core.setOutput("pushECR", Boolean(context.payload.inputs?.pushECR ?? true));
             } else {
               core.setFailed('Unknown event type');
             }

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -83,9 +83,9 @@ jobs:
               core.setOutput("minorVersion", minorVersion);
               core.setOutput("dryRun", dryRun);
               core.setOutput("releaseType", eventType);
-              core.setOutput("pushDockerHub", 'true');
-              core.setOutput("pushGHCR", 'true');
-              core.setOutput("pushECR", 'true');
+              core.setOutput("pushDockerHub", context.payload.client_payload.pushDockerHub ?? true);
+              core.setOutput("pushGHCR", context.payload.client_payload.pushGHCR ?? true);
+              core.setOutput("pushECR", context.payload.client_payload.pushECR ?? true);
             } else if (context.payload.inputs) {
               eventType = context.payload.inputs.releaseType || 'liquibase-release';
               liquibaseVersion = context.payload.inputs.liquibaseVersion;

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -346,77 +346,77 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.generate-tags.outputs.tags }}
 
-  update-official-repo:
-    name: "Update Official Docker Repo"
-    needs: update-dockerfiles
-    if: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' }}
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
-    steps:
-      - name: Extract major.minor version
-        id: extract_version
-        run: |
-          VERSION="${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
-          echo "MAJOR_MINOR=${VERSION%.*}" >> $GITHUB_ENV
-          echo "VERSION: $VERSION"
-          echo "MAJOR_MINOR: ${VERSION%.*}"
+  # update-official-repo:
+  #   name: "Update Official Docker Repo"
+  #   needs: update-dockerfiles
+  #   if: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' }}
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+  #   steps:
+  #     - name: Extract major.minor version
+  #       id: extract_version
+  #       run: |
+  #         VERSION="${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
+  #         echo "MAJOR_MINOR=${VERSION%.*}" >> $GITHUB_ENV
+  #         echo "VERSION: $VERSION"
+  #         echo "MAJOR_MINOR: ${VERSION%.*}"
 
-      - name: Check out liquibase/official-images
-        uses: actions/checkout@v4
-        with:
-          repository: liquibase/official-images
-          ref: master
-          token: ${{ env.GITHUB_TOKEN }}
+  #     - name: Check out liquibase/official-images
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: liquibase/official-images
+  #         ref: master
+  #         token: ${{ env.GITHUB_TOKEN }}
 
-      - name: Update library/liquibase in liquibase/official-images
-        run: |
-          echo "Maintainers: Jake Newton <docker@liquibase.com> (@jnewton03)" > library/liquibase
-          echo "Architectures: arm64v8, amd64" >> library/liquibase
-          echo "GitRepo: https://github.com/liquibase/docker.git" >> library/liquibase
-          echo "" >> library/liquibase
-          echo "Tags: ${{ env.MAJOR_MINOR }}, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}, latest" >> library/liquibase
-          echo "GitFetch: refs/heads/main" >> library/liquibase
-          echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
-          echo "File: Dockerfile" >> library/liquibase
-          echo "" >> library/liquibase
-          echo "Tags: ${{ env.MAJOR_MINOR }}-alpine, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}-alpine, alpine" >> library/liquibase
-          echo "GitFetch: refs/heads/main" >> library/liquibase
-          echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
-          echo "File: Dockerfile.alpine" >> library/liquibase
-          git add library/liquibase
-          if git diff-index --cached --quiet HEAD --
-            then
-              echo "Nothing new to commit"
-            else
-              git config user.name "liquibot"
-              git config user.email "liquibot@liquibase.org"
-              git commit -m "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
-              if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == false ]]; then
-                git push https://liquibot:$GITHUB_TOKEN@github.com/liquibase/official-images.git
-              else
-              echo "Dry run mode: changes have not been pushed."
-            fi
-          fi
+  #     - name: Update library/liquibase in liquibase/official-images
+  #       run: |
+  #         echo "Maintainers: Jake Newton <docker@liquibase.com> (@jnewton03)" > library/liquibase
+  #         echo "Architectures: arm64v8, amd64" >> library/liquibase
+  #         echo "GitRepo: https://github.com/liquibase/docker.git" >> library/liquibase
+  #         echo "" >> library/liquibase
+  #         echo "Tags: ${{ env.MAJOR_MINOR }}, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}, latest" >> library/liquibase
+  #         echo "GitFetch: refs/heads/main" >> library/liquibase
+  #         echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
+  #         echo "File: Dockerfile" >> library/liquibase
+  #         echo "" >> library/liquibase
+  #         echo "Tags: ${{ env.MAJOR_MINOR }}-alpine, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}-alpine, alpine" >> library/liquibase
+  #         echo "GitFetch: refs/heads/main" >> library/liquibase
+  #         echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
+  #         echo "File: Dockerfile.alpine" >> library/liquibase
+  #         git add library/liquibase
+  #         if git diff-index --cached --quiet HEAD --
+  #           then
+  #             echo "Nothing new to commit"
+  #           else
+  #             git config user.name "liquibot"
+  #             git config user.email "liquibot@liquibase.org"
+  #             git commit -m "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
+  #             if [[ "${{ needs.update-dockerfiles.outputs.dryRun }}" == false ]]; then
+  #               git push https://liquibot:$GITHUB_TOKEN@github.com/liquibase/official-images.git
+  #             else
+  #             echo "Dry run mode: changes have not been pushed."
+  #           fi
+  #         fi
 
-      - name: Create Official Docker Pull Request
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-        id: create_pr
-        run: |
-          response=$(curl \
-            -X POST \
-            -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/docker-library/official-images/pulls \
-            -d '{
-              "title": "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}",
-              "body": "Update library/liquibase with latest commit and version",
-              "head": "liquibase:master",
-              "base": "master"
-            }')
-          pr_url=$(echo $response | jq -r '.html_url')
-          echo "PR_URL=$pr_url" >> $GITHUB_ENV
+  #     - name: Create Official Docker Pull Request
+  #       if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+  #       id: create_pr
+  #       run: |
+  #         response=$(curl \
+  #           -X POST \
+  #           -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
+  #           -H "Accept: application/vnd.github.v3+json" \
+  #           https://api.github.com/repos/docker-library/official-images/pulls \
+  #           -d '{
+  #             "title": "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}",
+  #             "body": "Update library/liquibase with latest commit and version",
+  #             "head": "liquibase:master",
+  #             "base": "master"
+  #           }')
+  #         pr_url=$(echo $response | jq -r '.html_url')
+  #         echo "PR_URL=$pr_url" >> $GITHUB_ENV
 
-      - name: Adding Official Docker PR to job summary
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
-        run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY
+  #     - name: Adding Official Docker PR to job summary
+  #       if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' }}
+  #       run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Test liquibase version
         run: |
-          LOG_STRING="Liquibase Version:"
+          LOG_STRING="Starting Liquibase"
           # Check if the container is running
           if docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null | grep -q "true"; then
               # Get the logs and check if the desired string is present

--- a/DockerfilePro
+++ b/DockerfilePro
@@ -6,11 +6,20 @@ RUN groupadd --gid 1001 liquibase && \
     useradd --uid 1001 --gid liquibase --create-home --home-dir /liquibase liquibase && \
     chown liquibase /liquibase
 
-# Download and install Liquibase
-WORKDIR /liquibase
-
+# Define ARGs before using them in LABELs
 ARG LIQUIBASE_PRO_VERSION=4.32.0-RC1
 ARG LB_PRO_SHA256=8da09e9c3a4e8c869b0bf432c1813dcebe426c41b6a5e6b9a084d6f087f11d02
+
+# Add metadata labels
+LABEL org.opencontainers.image.source="https://github.com/liquibase/docker"
+LABEL org.opencontainers.image.description="Liquibase Pro Container Image"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="Liquibase"
+LABEL org.opencontainers.image.version="${LIQUIBASE_PRO_VERSION}"
+LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"
+
+# Download and install Liquibase
+WORKDIR /liquibase
 
 RUN wget -q -O liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz "https://repo.liquibase.com/releases/pro/${LIQUIBASE_PRO_VERSION}/liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz" && \
     echo "$LB_PRO_SHA256 *liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz" | sha256sum -c - && \

--- a/DockerfilePro
+++ b/DockerfilePro
@@ -6,9 +6,11 @@ RUN groupadd --gid 1001 liquibase && \
     useradd --uid 1001 --gid liquibase --create-home --home-dir /liquibase liquibase && \
     chown liquibase /liquibase
 
-# Define ARGs before using them in LABELs
-ARG LIQUIBASE_PRO_VERSION=4.32.0-RC1
-ARG LB_PRO_SHA256=8da09e9c3a4e8c869b0bf432c1813dcebe426c41b6a5e6b9a084d6f087f11d02
+# Download and install Liquibase
+WORKDIR /liquibase
+
+ARG LIQUIBASE_PRO_VERSION=4.32.0
+ARG LB_PRO_SHA256=e91175e1c1bcc33afb14f21d6899052bae6070ca87997869c7c29f6c75bb7374
 
 # Add metadata labels
 LABEL org.opencontainers.image.source="https://github.com/liquibase/docker"

--- a/README.md
+++ b/README.md
@@ -8,19 +8,50 @@ We are excited to announce that a new official Liquibase Docker image is now ava
 
 Please update your Dockerfiles and scripts to pull from the new official image:
 
+## Available Registries
+
+We publish this image to multiple registries:
+
+| Registry | Image |
+|----------|-------|
+| **Docker Hub (default)** | `liquibase/liquibase` |
+| **GitHub Container Registry** | `ghcr.io/liquibase/liquibase` |
+| **Amazon ECR Public** | `public.ecr.aws/liquibase/liquibase` |
+
 ## Dockerfile
 
 ```dockerfile
 FROM liquibase:latest
+# OR ghcr.io/liquibase/liquibase:latest    # GHCR  
+# OR public.ecr.aws/liquibase/liquibase:latest   # Amazon ECR Public
 ```
 
 ## Scripts
 
 ```bash
-docker pull liquibase
+# Docker Hub (default)
+docker pull liquibase/liquibase
+
+# GitHub Container Registry
+docker pull ghcr.io/liquibase/liquibase
+
+# Amazon ECR Public
+docker pull public.ecr.aws/liquibase/liquibase
 ```
 
-In the future, we will stop updating the community `liquibase/liquibase` Docker image. Transition to the new official image to ensure you continue receiving updates and support.
+### Pulling the Latest or Specific Version
+
+```bash
+# Latest
+docker pull liquibase/liquibase:latest
+docker pull ghcr.io/liquibase/liquibase:latest
+docker pull public.ecr.aws/liquibase/liquibase:latest
+
+# Specific version (example: 4.27.0)
+docker pull liquibase/liquibase:4.27.0
+docker pull ghcr.io/liquibase/liquibase:4.27.0
+docker pull public.ecr.aws/liquibase/liquibase:4.27.0
+```
 
 For any questions or support, please visit our [Liquibase Community Forum](https://forum.liquibase.org/).
 


### PR DESCRIPTION
This pull request enhances the release workflow by adding support for selectively publishing Docker images to multiple container registries (Docker Hub, GitHub Container Registry, and AWS Public ECR). It also updates the `README.md` to document the available registries and usage instructions. 

### Workflow Enhancements:
* Added new input parameters (`pushDockerHub`, `pushGHCR`, `pushECR`) to the `create-release.yml` workflow to control whether images are published to Docker Hub, GitHub Container Registry, or AWS Public ECR. These parameters default to `true`.
* Updated the `update-dockerfiles` job to set outputs for the new parameters, enabling conditional logic for registry-specific steps. [[1]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R57-R59) [[2]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R86-R88) [[3]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R99-R101)
* Modified the `Build and Push Docker Images` job to use environment variables for registry-specific conditions and to skip login or tagging steps if a registry is not selected. [[1]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R186-R189) [[2]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L226-R266) [[3]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L271-L294)

### Documentation Updates:
* Added a new section in `README.md` to list the available registries and provide examples for pulling images from Docker Hub, GitHub Container Registry, and AWS Public ECR.