### PR TITLE
🔧 DAT-20252 : add GitHub App token 

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -120,6 +120,15 @@ jobs:
           persist-credentials: false
           ref: ${{ github.ref }}
 
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -179,7 +188,7 @@ jobs:
             fi
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
 
       - name: Get latest commit SHA
         id: get-latest-sha


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/create-release.yml` to enhance security by replacing the default `GITHUB_TOKEN` with a token generated using a GitHub App. The most important changes are as follows:

### Security Enhancements:

* Added a new step, "Get GitHub App token," to generate a token using `actions/create-github-app-token@v2`. This step uses secrets for the GitHub App ID and private key, and sets the `permission-contents` to `write`. (`[.github/workflows/create-release.ymlR123-R131](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R123-R131)`)
* Updated the `GITHUB_TOKEN` environment variable to use the token generated in the "Get GitHub App token" step instead of the default token provided by GitHub Actions. (`[.github/workflows/create-release.ymlL182-R191](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L182-R191)`)