### PR TITLE
DAT-20252 🔧 (create-release.yml): replace hardcoded GitHub user credentials with token-based authentication for git push operations

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -135,11 +135,6 @@ jobs:
           java-version: "8"
           distribution: "adopt"
 
-      - name: Configure git user
-        run: |
-          git config user.name "liquibot"
-          git config user.email "liquibot@liquibase.org"
-
       - name: Update Dockerfile(s) and commit changes
         run: |
           if [[ "${{ steps.collect-data.outputs.releaseType }}" == "liquibase-pro-release" ]]; then
@@ -158,7 +153,7 @@ jobs:
               git commit -m "Liquibase PRO Version Bumped to ${{ steps.collect-data.outputs.liquibaseVersion }}"
               if [[ "${{ steps.collect-data.outputs.dryRun }}" == false ]]; then
                 git tag -fa -m "Version Bumped to ${{ steps.collect-data.outputs.liquibaseVersion }}" v${{ steps.collect-data.outputs.liquibaseVersion }}
-                git push -f "https://liquibot:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.ref }} --follow-tags --tags
+                git push -f "https://x-access-token:${{ steps.get-token.outputs.token }}@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.ref }} --follow-tags --tags
               else
                 echo "Dry run mode: changes have not been pushed."
               fi
@@ -181,7 +176,7 @@ jobs:
               git commit -m "Liquibase Version Bumped to ${{ steps.collect-data.outputs.extensionVersion }}"
               if [[ "${{ steps.collect-data.outputs.dryRun }}" == false ]]; then
                 git tag -fa -m "Version Bumped to ${{ steps.collect-data.outputs.extensionVersion }}" v${{ steps.collect-data.outputs.extensionVersion }}
-                git push -f "https://liquibot:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.ref }} --follow-tags --tags
+                git push -f "https://x-access-token:${{ steps.get-token.outputs.token }}@github.com/$GITHUB_REPOSITORY.git" HEAD:${{ github.ref }} --follow-tags --tags
               else
                 echo "Dry run mode: changes have not been pushed."
               fi


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/create-release.yml` to improve security and streamline the release process. The key changes include replacing hardcoded credentials with a dynamically generated token and removing redundant Git configuration steps.

Improvements to security:

* Updated the Git push command to use a dynamically generated token (`steps.get-token.outputs.token`) instead of the hardcoded `GITHUB_TOKEN`, enhancing security by reducing exposure of sensitive credentials. [[1]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L161-R156) [[2]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L184-R179)

Streamlining the workflow:

* Removed the redundant "Configure git user" step, as it is no longer necessary for the workflow.