### PR TITLE
🔧 uses: actions/create-github-app-token@v2

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -402,7 +402,7 @@ jobs:
 
       - name: Get GitHub App token
         id: get-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the `actions/create-github-app-token` action.

* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L405-R405): Updated the `actions/create-github-app-token` action from version `v1` to `v2` to ensure compatibility with the latest features and improvements.