### PR TITLE
Publish Liquibase Pro Image to GHCR and AWS ECR

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -258,8 +258,8 @@ jobs:
             echo "GHCR_REPO=ghcr.io/liquibase/liquibase" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.type }}" == "liquibase-pro-release" ]]; then
             echo "DOCKERHUB_REPO=${{ matrix.name }}" >> $GITHUB_OUTPUT
-            echo "ECR_REPO=" >> $GITHUB_OUTPUT
-            echo "GHCR_REPO=" >> $GITHUB_OUTPUT
+            echo "ECR_REPO=public.ecr.aws/liquibase/liquibase-pro" >> $GITHUB_OUTPUT
+            echo "GHCR_REPO=ghcr.io/liquibase/liquibase-pro" >> $GITHUB_OUTPUT
           fi
 
       # Use separate login steps for each registry

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Please update your Dockerfiles and scripts to pull from the new official image:
 
 We publish this image to multiple registries:
 
-| Registry | Image |
-|----------|-------|
-| **Docker Hub (default)** | `liquibase/liquibase` |
-| **GitHub Container Registry** | `ghcr.io/liquibase/liquibase` |
-| **Amazon ECR Public** | `public.ecr.aws/liquibase/liquibase` |
+| Registry | OSS Image | Pro Image |
+|----------|----------------|-----------|
+| **Docker Hub (default)** | `liquibase/liquibase` | `liquibase/liquibase-pro` |
+| **GitHub Container Registry** | `ghcr.io/liquibase/liquibase` | `ghcr.io/liquibase/liquibase-pro` |
+| **Amazon ECR Public** | `public.ecr.aws/liquibase/liquibase` | `public.ecr.aws/liquibase/liquibase-pro` |
 
 ## Dockerfile
 
@@ -28,18 +28,35 @@ FROM liquibase:latest
 
 ## Scripts
 
+### OSS Edition
+
 ```bash
-# Docker Hub (default)
+# Docker Hub (default)
 docker pull liquibase/liquibase
 
 # GitHub Container Registry
 docker pull ghcr.io/liquibase/liquibase
 
-# Amazon ECR Public
+# Amazon ECR Public
 docker pull public.ecr.aws/liquibase/liquibase
 ```
 
+### Pro Edition
+
+```bash
+# Docker Hub (default)
+docker pull liquibase/liquibase-pro
+
+# GitHub Container Registry
+docker pull ghcr.io/liquibase/liquibase-pro
+
+# Amazon ECR Public
+docker pull public.ecr.aws/liquibase/liquibase-pro
+```
+
 ### Pulling the Latest or Specific Version
+
+#### OSS Edition
 
 ```bash
 # Latest
@@ -47,10 +64,24 @@ docker pull liquibase/liquibase:latest
 docker pull ghcr.io/liquibase/liquibase:latest
 docker pull public.ecr.aws/liquibase/liquibase:latest
 
-# Specific version (example: 4.27.0)
-docker pull liquibase/liquibase:4.27.0
-docker pull ghcr.io/liquibase/liquibase:4.27.0
-docker pull public.ecr.aws/liquibase/liquibase:4.27.0
+# Specific version (example: 4.32.0)
+docker pull liquibase/liquibase:4.32.0
+docker pull ghcr.io/liquibase/liquibase:4.32.0
+docker pull public.ecr.aws/liquibase/liquibase:4.32.0
+```
+
+#### Pro Edition
+
+```bash
+# Latest
+docker pull liquibase/liquibase-pro:latest
+docker pull ghcr.io/liquibase/liquibase-pro:latest
+docker pull public.ecr.aws/liquibase/liquibase-pro:latest
+
+# Specific version (example: 4.32.0)
+docker pull liquibase/liquibase-pro:4.32.0
+docker pull ghcr.io/liquibase/liquibase-pro:4.32.0
+docker pull public.ecr.aws/liquibase/liquibase-pro:4.32.0
 ```
 
 For any questions or support, please visit our [Liquibase Community Forum](https://forum.liquibase.org/).


### PR DESCRIPTION
This pull request introduces updates to the release workflow and documentation to support both the OSS and Pro editions of Liquibase Docker images. Key changes include modifications to the `.github/workflows/create-release.yml` file and the `README.md` to reflect the new Pro image and registry details.

### Workflow Updates:
* Updated the `create-release.yml` workflow to include `ECR_REPO` and `GHCR_REPO` values for the Pro edition (`liquibase-pro`) in the release process. (`.github/workflows/create-release.yml`, [.github/workflows/create-release.ymlL261-R262](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L261-R262))

### Documentation Updates:
* Revised the registry table in the `README.md` to include both OSS and Pro images for Docker Hub, GitHub Container Registry, and Amazon ECR Public. (`README.md`, [README.mdL15-R19](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R19))
* Added separate sections in the `README.md` for pulling the latest and specific versions of both OSS and Pro editions, with updated examples for version `4.32.0`. (`README.md`, [README.mdR31-R84](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R84))