### PR TITLE
Docker Official fixes (ARGS/LABELs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,20 @@ RUN groupadd --gid 1001 liquibase && \
     useradd --uid 1001 --gid liquibase --create-home --home-dir /liquibase liquibase && \
     chown liquibase /liquibase
 
+# Download and install Liquibase
+WORKDIR /liquibase
+
 ARG LIQUIBASE_VERSION=4.32.0
 ARG LB_SHA256=10910d42ae9990c95a4ac8f0a3665a24bd40d08fb264055d78b923a512774d54
+
+RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" && \
+    echo "$LB_SHA256 *liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - && \
+    tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz && \
+    rm liquibase-${LIQUIBASE_VERSION}.tar.gz && \
+    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \
+    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
+    liquibase --version
+    
 ARG LPM_VERSION=0.2.9
 ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
 ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
@@ -18,17 +30,6 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.vendor="Liquibase"
 LABEL org.opencontainers.image.version="${LIQUIBASE_VERSION}"
 LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"
-
-# Download and install Liquibase
-WORKDIR /liquibase
-
-RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" && \
-    echo "$LB_SHA256 *liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - && \
-    tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz && \
-    rm liquibase-${LIQUIBASE_VERSION}.tar.gz && \
-    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \
-    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
-    liquibase --version
 
 # Download and Install lpm
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
 # Builder Stage
 FROM eclipse-temurin:21-jre-jammy
 
-ARG LIQUIBASE_VERSION=4.32.0
-ARG LB_SHA256=10910d42ae9990c95a4ac8f0a3665a24bd40d08fb264055d78b923a512774d54
-ARG LPM_VERSION=0.2.9
-ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
-ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
-
 # Create liquibase user
 RUN groupadd --gid 1001 liquibase && \
     useradd --uid 1001 --gid liquibase --create-home --home-dir /liquibase liquibase && \
     chown liquibase /liquibase
 
+ARG LIQUIBASE_VERSION=4.32.0
+ARG LB_SHA256=10910d42ae9990c95a4ac8f0a3665a24bd40d08fb264055d78b923a512774d54
+ARG LPM_VERSION=0.2.9
+ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
+ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
+    
 # Add metadata labels
-LABEL org.opencontainers.image.source="https://github.com/liquibase/docker"
 LABEL org.opencontainers.image.description="Liquibase Container Image"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.vendor="Liquibase"

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,20 +9,10 @@ RUN addgroup --gid 1001 liquibase && \
 # Install smaller JRE, if available and acceptable
 RUN apk add --no-cache openjdk21-jre-headless bash
 
+WORKDIR /liquibase
+
 ARG LIQUIBASE_VERSION=4.32.0
 ARG LB_SHA256=10910d42ae9990c95a4ac8f0a3665a24bd40d08fb264055d78b923a512774d54
-ARG LPM_VERSION=0.2.9
-ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
-ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
-
-# Add metadata labels
-LABEL org.opencontainers.image.description="Liquibase Container Image (Alpine)"
-LABEL org.opencontainers.image.licenses="Apache-2.0"
-LABEL org.opencontainers.image.vendor="Liquibase"
-LABEL org.opencontainers.image.version="${LIQUIBASE_VERSION}"
-LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"
-
-WORKDIR /liquibase
 
 # Download, verify, extract
 RUN set -x && \
@@ -35,6 +25,17 @@ RUN set -x && \
     ln -s /liquibase/liquibase /usr/local/bin/liquibase && \
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
+    
+ARG LPM_VERSION=0.2.9
+ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
+ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
+
+# Add metadata labels
+LABEL org.opencontainers.image.description="Liquibase Container Image (Alpine)"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="Liquibase"
+LABEL org.opencontainers.image.version="${LIQUIBASE_VERSION}"
+LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"
 
 # Download and Install lpm
 RUN mkdir /liquibase/bin && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,12 +1,6 @@
 # Use multi-stage build
 FROM alpine:3.21
 
-ARG LIQUIBASE_VERSION=4.32.0
-ARG LB_SHA256=10910d42ae9990c95a4ac8f0a3665a24bd40d08fb264055d78b923a512774d54
-ARG LPM_VERSION=0.2.9
-ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
-ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
-
 # Create liquibase user
 RUN addgroup --gid 1001 liquibase && \
     adduser --disabled-password --uid 1001 --ingroup liquibase --home /liquibase liquibase && \
@@ -15,8 +9,13 @@ RUN addgroup --gid 1001 liquibase && \
 # Install smaller JRE, if available and acceptable
 RUN apk add --no-cache openjdk21-jre-headless bash
 
+ARG LIQUIBASE_VERSION=4.32.0
+ARG LB_SHA256=10910d42ae9990c95a4ac8f0a3665a24bd40d08fb264055d78b923a512774d54
+ARG LPM_VERSION=0.2.9
+ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
+ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
+
 # Add metadata labels
-LABEL org.opencontainers.image.source="https://github.com/liquibase/docker"
 LABEL org.opencontainers.image.description="Liquibase Container Image (Alpine)"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.vendor="Liquibase"

--- a/DockerfilePro
+++ b/DockerfilePro
@@ -13,7 +13,6 @@ ARG LIQUIBASE_PRO_VERSION=4.32.0
 ARG LB_PRO_SHA256=69adc7b73458af84b286bcdc7b9d2148c77a8dadeb85580e50c9fc9a90c19ed4
 
 # Add metadata labels
-LABEL org.opencontainers.image.source="https://github.com/liquibase/docker"
 LABEL org.opencontainers.image.description="Liquibase Pro Container Image"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.vendor="Liquibase"


### PR DESCRIPTION
As per their requests here: https://github.com/docker-library/official-images/pull/19077

I think we only need to move the `ARGs` and remove `LABEL org.opencontainers.image.source="https://github.com/liquibase/docker"` because they are already adding that label on their CI


This pull request makes adjustments to the `Dockerfile` and `Dockerfile.alpine` to improve the structure and organization of the build process. The key changes involve reordering the creation of the `liquibase` user, relocating `ARG` declarations, and modifying metadata labels.

### Changes to Dockerfile structure and organization:

* Moved the creation of the `liquibase` user earlier in the `Dockerfile` to improve build clarity and consistency. (`Dockerfile`, [DockerfileR4-L16](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R4-L16))
* Relocated `ARG` declarations (`LIQUIBASE_VERSION`, `LB_SHA256`, `LPM_VERSION`, etc.) to a later stage in `Dockerfile.alpine` for better alignment with the build process. (`Dockerfile.alpine`, [Dockerfile.alpineR12-L19](diffhunk://#diff-f865864730d7062c04cc13b1b85ba03ed5dbef3fa02fcb50b87d9117d0af1f4eR12-L19))

### Metadata label adjustments:

* Removed the `org.opencontainers.image.source` label from both `Dockerfile` and `Dockerfile.alpine`, likely to streamline metadata. (`Dockerfile`, [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R4-L16); `Dockerfile.alpine`, [[2]](diffhunk://#diff-f865864730d7062c04cc13b1b85ba03ed5dbef3fa02fcb50b87d9117d0af1f4eR12-L19)