### PR TITLE
DAT-20320:add workflow to publish Liquibase Pro and OSS README to Docker Hub

### DIFF
--- a/.github/workflows/publish-oss-readme.yml
+++ b/.github/workflows/publish-oss-readme.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: liquibase/docker
-          readme-filepath: ./README.md
+          repository: liquibase/liquibase
+          readme-filepath: README.md
           short-description: "Liquibase OSS"

--- a/.github/workflows/publish-oss-readme.yml
+++ b/.github/workflows/publish-oss-readme.yml
@@ -1,0 +1,26 @@
+name: Publish Liquibase OSS README to Docker Hub
+
+on:
+  push:
+    paths:
+      - 'README.md'
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-liquibase-oss-readme:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Update Liquibase OSS README on Docker Hub
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: liquibase/docker
+          readme-filepath: ./README.md
+          short-description: "Liquibase OSS"

--- a/.github/workflows/publish-pro-readme.yml
+++ b/.github/workflows/publish-pro-readme.yml
@@ -1,0 +1,26 @@
+name: Publish Liquibase Pro README to Docker Hub
+
+on:
+  push:
+    paths:
+      - 'README-pro.md'
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-liquibase-pro-readme:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Update Docker Hub README
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: liquibase/docker
+          readme-filepath: ./README-pro.md
+          short-description: "Liquibase Pro"

--- a/.github/workflows/publish-pro-readme.yml
+++ b/.github/workflows/publish-pro-readme.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         
-      - name: Update Docker Hub README
+      - name: Update Liquibase Pro README on Docker Hub
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: liquibase/docker
+          repository: liquibase/liquibase-pro
           readme-filepath: ./README-pro.md
           short-description: "Liquibase Pro"

--- a/README-pro.md
+++ b/README-pro.md
@@ -1,0 +1,274 @@
+# Official Liquibase-Pro Docker Images
+
+**Liquibase Pro** is the enterprise edition of Liquibase that provides advanced database DevOps capabilities for teams requiring enhanced security, performance, and governance features.
+
+## ⚠️ License Requirements
+
+> **WARNING**: Liquibase Pro requires a valid license key to use Pro features. Without a license, the container will run in Liquibase Community mode with limited functionality.
+>
+> - Contact [Liquibase Sales](https://www.liquibase.com/community/contact) to obtain a Pro license
+> - Existing customers can find their license key in the [Liquibase Account Portal](https://account.liquibase.com/)
+
+## 📋 Pro Features
+
+Liquibase Pro is the enterprise edition of [Liquibase](https://www.liquibase.com/) that provides advanced database DevOps capabilities for teams requiring enhanced security, performance, and governance features.
+
+Liquibase Pro includes all Community features plus:
+
+### 🔐 Security & Governance
+
+- **Policy Checks**: Enforce database standards and best practices
+- **Quality Checks**: Advanced validation rules for changesets  
+- **Rollback SQL**: Generate rollback scripts for any deployment
+- **Targeted Rollback**: Rollback specific changesets without affecting others
+- **Advanced Database Support**: Enhanced support for Oracle, SQL Server, and other enterprise databases
+- **Audit Reports**: Comprehensive tracking of database changes
+- **Stored Logic**: Support for functions, procedures, packages, and triggers
+
+## 🔧 Environment Variables
+
+### Pro License Environment Variable
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `LIQUIBASE_LICENSE_KEY` | Your Liquibase Pro license key | `ABcd-1234-EFGH-5678` |
+
+### 🔧 Action Required
+
+Please update your Dockerfiles and scripts to pull from the new official image:
+
+## Available Registries
+
+We publish this image to multiple registries:
+
+| Registry | Pro Image |
+|----------|-----------|
+| **Docker Hub (default)** | `liquibase/liquibase-pro` |
+| **GitHub Container Registry** | `ghcr.io/liquibase/liquibase-pro` |
+| **Amazon ECR Public** | `public.ecr.aws/liquibase/liquibase-pro` |
+
+## Dockerfile
+
+```dockerfile
+FROM liquibase:latest
+# OR ghcr.io/liquibase/liquibase-pro:latest    # GHCR  
+# OR public.ecr.aws/liquibase/liquibase-pro:latest   # Amazon ECR Public
+```
+
+## Scripts
+
+### Pro Edition
+
+```bash
+# Docker Hub (default)
+docker pull liquibase/liquibase-pro
+
+# GitHub Container Registry
+docker pull ghcr.io/liquibase/liquibase-pro
+
+# Amazon ECR Public
+docker pull public.ecr.aws/liquibase/liquibase-pro
+```
+
+### Pulling the Latest or Specific Version
+
+#### Pulling Pro Edition Images
+
+```bash
+# Latest
+docker pull liquibase/liquibase-pro:latest
+docker pull ghcr.io/liquibase/liquibase-pro:latest
+docker pull public.ecr.aws/liquibase/liquibase-pro:latest
+
+# Specific version (example: 4.32.0)
+docker pull liquibase/liquibase-pro:4.32.0
+docker pull ghcr.io/liquibase/liquibase-pro:4.32.0
+docker pull public.ecr.aws/liquibase/liquibase-pro:4.32.0
+```
+
+For any questions or support, please visit our [Liquibase Community Forum](https://forum.liquibase.org/).
+
+## 🏷️ Supported Tags
+
+The following tags are officially supported and can be found on [Docker Hub](https://hub.docker.com/r/liquibase/liquibase-pro/tags):
+
+- `liquibase/liquibase-pro:<version>`
+- `liquibase/liquibase-pro:<version>-alpine`
+
+### Database Connection Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `LIQUIBASE_COMMAND_URL` | Database JDBC URL | `jdbc:postgresql://db:5432/mydb` |
+| `LIQUIBASE_COMMAND_USERNAME` | Database username | `dbuser` |
+| `LIQUIBASE_COMMAND_PASSWORD` | Database password | `dbpass` |
+| `LIQUIBASE_COMMAND_CHANGELOG_FILE` | Path to changelog file | `/liquibase/changelog/changelog.xml` |
+
+### Pro-Specific Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `LIQUIBASE_PRO_POLICY_CHECKS_ENABLED` | Enable policy checks | `true` |
+| `LIQUIBASE_PRO_QUALITY_CHECKS_ENABLED` | Enable quality checks | `true` |
+| `LIQUIBASE_REPORTS_ENABLED` | Enable HTML reports | `true` |
+| `LIQUIBASE_REPORTS_PATH` | Reports output directory | `/tmp/reports` |
+
+## Required License Configuration
+
+Set your Liquibase Pro license key using the `LIQUIBASE_LICENSE_KEY` environment variable:
+
+```bash
+$ docker run --rm \
+    -e LIQUIBASE_LICENSE_KEY="YOUR_LICENSE_KEY_HERE" \
+    -v /path/to/changelog:/liquibase/changelog \
+    liquibase/liquibase-pro \
+    --changelog-file=example-changelog.xml \
+    --url="jdbc:postgresql://host.docker.internal:5432/testdb" \
+    --username=postgres \
+    --password=password \
+    --search-path=/liquibase/changelog/ \
+    update
+```
+
+## Mounting Changelog Files
+
+Mount your changelog directory to the `/liquibase/changelog` volume and use the `--search-path` parameter to specify the location.
+
+```bash
+$ docker run --rm \
+    -e LIQUIBASE_LICENSE_KEY="YOUR_LICENSE_KEY_HERE" \
+    -v "$(pwd)":/liquibase/changelog \
+    liquibase/liquibase-pro \
+    --changelog-file=example-changelog.xml \
+    --search-path=/liquibase/changelog/ \
+    update
+```
+
+## Using a Properties File
+
+To use a default configuration file, mount it in your changelog volume and reference it with the `--defaults-file` argument.
+
+```bash
+$ docker run --rm \
+    -e LIQUIBASE_LICENSE_KEY="YOUR_LICENSE_KEY_HERE" \
+    -v /path/to/changelog:/liquibase/changelog \
+    liquibase/liquibase-pro \
+    --defaults-file=liquibase.properties update
+```
+
+Example `liquibase.properties` file:
+
+```bash
+url=jdbc:postgresql://host.docker.internal:5432/testdb
+username=postgres
+password=password
+changelog-file=example-changelog.xml
+search-path=/liquibase/changelog/
+liquibase.licenseKey=<PASTE LB PRO LICENSE KEY HERE>
+```
+
+## Adding Additional JARs
+
+Mount a local directory containing additional jars to `/liquibase/lib`.
+
+```bash
+$ docker run --rm \
+    -e LIQUIBASE_LICENSE_KEY="YOUR_LICENSE_KEY_HERE" \
+    -v /path/to/changelog:/liquibase/changelog \
+    -v /path/to/lib:/liquibase/lib \
+    liquibase/liquibase-pro update
+
+## 📦 Using the Docker Image
+
+### 🏷️ Standard Image
+
+The `liquibase/liquibase-pro:<version>` image is the standard choice. Use it as a disposable container or a foundational building block for other images.
+
+For examples of extending the standard image, see the [standard image examples](https://github.com/liquibase/docker/tree/main/examples).
+
+### 🏷️ Alpine Image
+
+The `liquibase/liquibase-pro:<version>-alpine` image is a lightweight version designed for environments with limited resources. It is built on Alpine Linux and has a smaller footprint.
+
+# Extending Liquibase Pro Docker Image Examples
+
+## AWS CLI Integration
+
+**Dockerfile:**
+
+```dockerfile
+FROM liquibase/liquibase-pro:latest-alpine
+
+USER root
+
+RUN apk add --no-cache wget unzip
+
+RUN wget "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -O "awscliv2.zip" && \
+  unzip awscliv2.zip && rm -rf awscliv2.zip && \
+  ./aws/install
+
+USER liquibase
+```
+
+**Usage:**
+
+```bash
+# Build the image
+docker build . -t liquibase-pro-aws
+
+# Run with AWS credentials
+docker run --rm \
+  -e AWS_ACCESS_KEY_ID="your-access-key" \
+  -e AWS_SECRET_ACCESS_KEY="your-secret-key" \
+  -e LIQUIBASE_LICENSE_KEY="your-license-key" \
+  -v "$(pwd)":/liquibase/changelog \
+  liquibase-pro-aws \
+  --changelog-file=changelog.xml \
+  --search-path=/liquibase/changelog/ \
+  update
+```
+
+### 🐳 Docker Compose Example
+
+For a complete example using Docker Compose with PostgreSQL:
+
+```yaml
+version: '3.8'
+services:
+  liquibase:
+    image: liquibase/liquibase-pro:latest
+    environment:
+      LIQUIBASE_LICENSE_KEY: "${LIQUIBASE_LICENSE_KEY}"
+      LIQUIBASE_COMMAND_URL: "jdbc:postgresql://postgres:5432/example"
+      LIQUIBASE_COMMAND_USERNAME: "liquibase"
+      LIQUIBASE_COMMAND_PASSWORD: "liquibase"
+      LIQUIBASE_COMMAND_CHANGELOG_FILE: "changelog.xml"
+    volumes:
+      - ./changelog:/liquibase/changelog
+    depends_on:
+      - postgres
+    command: update
+
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: example
+      POSTGRES_USER: liquibase
+      POSTGRES_PASSWORD: liquibase
+    ports:
+      - "5432:5432"
+```
+
+## License
+
+This Docker image contains Liquibase Pro software which requires a valid commercial license for use.
+
+For licensing questions, please contact [Liquibase Sales](https://www.liquibase.com/contact).
+
+View [license information](https://www.liquibase.com/eula) for the software contained in this image.
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+Some additional license information which was able to be auto-detected might be found in [the `repo-info` repository's `liquibase/` directory](https://github.com/docker-library/repo-info/tree/master/repos/liquibase).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.

--- a/README-pro.md
+++ b/README-pro.md
@@ -7,7 +7,7 @@
 > **WARNING**: Liquibase Pro requires a valid license key to use Pro features. Without a license, the container will run in Liquibase Community mode with limited functionality.
 >
 > - Contact [Liquibase Sales](https://www.liquibase.com/community/contact) to obtain a Pro license
-> - Existing customers can find their license key in the [Liquibase Account Portal](https://account.liquibase.com/)
+> - Existing customers receive their Pro license keys in an email.
 
 ## 📋 Pro Features
 

--- a/README-pro.md
+++ b/README-pro.md
@@ -50,7 +50,7 @@ We publish this image to multiple registries:
 ## Dockerfile
 
 ```dockerfile
-FROM liquibase:latest
+FROM liquibase/liquibase-pro:latest
 # OR ghcr.io/liquibase/liquibase-pro:latest    # GHCR  
 # OR public.ecr.aws/liquibase/liquibase-pro:latest   # Amazon ECR Public
 ```
@@ -93,7 +93,6 @@ For any questions or support, please visit our [Liquibase Community Forum](https
 The following tags are officially supported and can be found on [Docker Hub](https://hub.docker.com/r/liquibase/liquibase-pro/tags):
 
 - `liquibase/liquibase-pro:<version>`
-- `liquibase/liquibase-pro:<version>-alpine`
 
 ### Database Connection Variables
 
@@ -164,7 +163,7 @@ username=postgres
 password=password
 changelog-file=example-changelog.xml
 search-path=/liquibase/changelog/
-liquibase.licenseKey=<PASTE LB PRO LICENSE KEY HERE>
+licenseKey=<PASTE LB PRO LICENSE KEY HERE>
 ```
 
 ## Adding Additional JARs
@@ -186,29 +185,6 @@ The `liquibase/liquibase-pro:<version>` image is the standard choice. Use it as 
 
 For examples of extending the standard image, see the [standard image examples](https://github.com/liquibase/docker/tree/main/examples).
 
-### 🏷️ Alpine Image
-
-The `liquibase/liquibase-pro:<version>-alpine` image is a lightweight version designed for environments with limited resources. It is built on Alpine Linux and has a smaller footprint.
-
-# Extending Liquibase Pro Docker Image Examples
-
-## AWS CLI Integration
-
-**Dockerfile:**
-
-```dockerfile
-FROM liquibase/liquibase-pro:latest-alpine
-
-USER root
-
-RUN apk add --no-cache wget unzip
-
-RUN wget "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -O "awscliv2.zip" && \
-  unzip awscliv2.zip && rm -rf awscliv2.zip && \
-  ./aws/install
-
-USER liquibase
-```
 
 **Usage:**
 


### PR DESCRIPTION
This pull request introduces workflows to publish the Liquibase OSS and Pro README files to Docker Hub, along with the addition of a detailed `README-pro.md` file for Liquibase Pro. These changes streamline the process of keeping Docker Hub documentation up-to-date and provide comprehensive information about Liquibase Pro's features, usage, and licensing.

### Workflow Automation for README Publishing:
* [`.github/workflows/publish-oss-readme.yml`](diffhunk://#diff-f859117c0e40e66626354f7a158888db5f66ce7ba9cc379aa8ebce2cd19dec59R1-R26): Added a workflow to automatically publish updates to the Liquibase OSS README (`README.md`) to Docker Hub when changes are pushed to the `main` branch.
* [`.github/workflows/publish-pro-readme.yml`](diffhunk://#diff-4c23dd0ff3c9cee93dbae92e53e46f10368d30c8ee26629f36d2547a5171083bR1-R26): Added a workflow to automatically publish updates to the Liquibase Pro README (`README-pro.md`) to Docker Hub when changes are pushed to the `main` branch.

### Documentation Enhancements:
* [`README-pro.md`](diffhunk://#diff-6df2dddab882f1203c08bb04ef702472eb9fb4ff5caa590cae661a0e89dd901eR1-R250): Added a detailed README for Liquibase Pro, including information about licensing requirements, features, environment variables, supported registries, usage examples, and Docker Compose integration. This provides users with comprehensive guidance on using Liquibase Pro with Docker.