### PR TITLE
🔧 DAT-20320: use token DOCKERHUB_UPDATE_README

### DIFF
--- a/.github/workflows/publish-oss-readme.yml
+++ b/.github/workflows/publish-oss-readme.yml
@@ -20,7 +20,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_UPDATE_README }}
           repository: liquibase/liquibase
           readme-filepath: README.md
           short-description: "Liquibase OSS"

--- a/.github/workflows/publish-pro-readme.yml
+++ b/.github/workflows/publish-pro-readme.yml
@@ -20,7 +20,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_UPDATE_README }}
           repository: liquibase/liquibase-pro
           readme-filepath: ./README-pro.md
           short-description: "Liquibase Pro"


### PR DESCRIPTION
This pull request updates the secrets used for authentication in two GitHub Actions workflows related to publishing DockerHub descriptions. Specifically, it replaces the `DOCKERHUB_TOKEN` secret with `DOCKERHUB_UPDATE_README` for improved security or functionality.

Internal Jira comment to check for the change : https://datical.atlassian.net/browse/DAT-20320?focusedCommentId=166492

Secrets update in workflows:

* [`.github/workflows/publish-oss-readme.yml`](diffhunk://#diff-f859117c0e40e66626354f7a158888db5f66ce7ba9cc379aa8ebce2cd19dec59L23-R23): Updated the `password` field to use `${{ secrets.DOCKERHUB_UPDATE_README }}` instead of `${{ secrets.DOCKERHUB_TOKEN }}` for publishing the Liquibase OSS DockerHub description.
* [`.github/workflows/publish-pro-readme.yml`](diffhunk://#diff-4c23dd0ff3c9cee93dbae92e53e46f10368d30c8ee26629f36d2547a5171083bL23-R23): Updated the `password` field to use `${{ secrets.DOCKERHUB_UPDATE_README }}` instead of `${{ secrets.DOCKERHUB_TOKEN }}` for publishing the Liquibase Pro DockerHub description.

