### PR TITLE
DAT-20401: PRO: Add LPM to liquibase/liquibase-pro docker image

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -158,6 +158,8 @@ jobs:
             for file in "${file_list[@]}"; do
               sed -i 's/^ARG LIQUIBASE_PRO_VERSION=.*/ARG LIQUIBASE_PRO_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LB_PRO_SHA256=.*/ARG LB_PRO_SHA256='"$LIQUIBASE_PRO_SHA"'/' "${{ github.workspace }}/${file}"
+              sed -i 's/^ARG LPM_SHA256=.*/ARG LPM_SHA256='"$LPM_SHA"'/' "${{ github.workspace }}/${file}"
+              sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
               git add "${file}"
             done
             if git diff-index --cached --quiet HEAD --; then
@@ -177,7 +179,7 @@ jobs:
               sed -i 's/^ARG LIQUIBASE_VERSION=.*/ARG LIQUIBASE_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LB_SHA256=.*/ARG LB_SHA256='"$LIQUIBASE_SHA"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LPM_SHA256=.*/ARG LPM_SHA256='"$LPM_SHA"'/' "${{ github.workspace }}/${file}"
-              #sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
+              sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
               git add "${file}"
             done
             if git diff-index --cached --quiet HEAD --; then

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   update-dockerfiles:
     env:
-      LPM_VERSION: "0.2.9"
+      LPM_VERSION: "0.2.10"
     name: "Update Dockerfiles"
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,6 @@ jobs:
           fi
 
       - name: Test extension loading
-        if: matrix.dockerfile != 'DockerfilePro'
         run: |
           LOG_STRING="liquibase-redshift"
           # Stop docker container
@@ -169,7 +168,6 @@ jobs:
           fi
 
       - name: Test driver connection
-        if: matrix.dockerfile != 'DockerfilePro'
         run: |
           LOG_STRING="successfully installed in classpath"
           docker stop $CONTAINER_NAME

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+This is the official Liquibase Docker image repository that builds and publishes Docker images for both Liquibase OSS and Liquibase Pro editions. The repository contains:
+
+- **Dockerfile**: Standard Liquibase OSS image
+- **DockerfilePro**: Liquibase Pro image with enterprise features
+- **Dockerfile.alpine**: Alpine Linux variant (lightweight)
+- **Examples**: Database-specific extensions (AWS CLI, SQL Server, PostgreSQL, Oracle)
+- **Docker Compose**: Complete example with PostgreSQL
+
+## Image Publishing
+
+Images are published to multiple registries:
+- Docker Hub: `liquibase/liquibase` (OSS) and `liquibase/liquibase-pro` (Pro)
+- GitHub Container Registry: `ghcr.io/liquibase/liquibase*`
+- Amazon ECR Public: `public.ecr.aws/liquibase/liquibase*`
+
+## Common Development Commands
+
+### Building Images
+
+```bash
+# Build OSS image
+docker build -f Dockerfile -t liquibase/liquibase:latest .
+
+# Build Pro image
+docker build -f DockerfilePro -t liquibase/liquibase-pro:latest .
+
+# Build Alpine variant
+docker build -f Dockerfile.alpine -t liquibase/liquibase:latest-alpine .
+```
+
+### Testing Images
+
+```bash
+# Test OSS image
+docker run --rm liquibase/liquibase:latest --version
+
+# Test Pro image (requires license)
+docker run --rm -e LIQUIBASE_LICENSE_KEY="your-key" liquibase/liquibase-pro:latest --version
+
+# Run with example changelog
+docker run --rm -v $(pwd)/examples/docker-compose/changelog:/liquibase/changelog liquibase/liquibase:latest --changelog-file=db.changelog-master.xml validate
+```
+
+### Docker Compose Example
+
+```bash
+# Run complete example with PostgreSQL
+cd examples/docker-compose
+docker-compose up
+
+# Use local build for testing
+docker-compose -f docker-compose.local.yml up --build
+```
+
+## Architecture
+
+### Base Image Structure
+- **Base**: Eclipse Temurin JRE 21 (Jammy)
+- **User**: Non-root `liquibase` user (UID/GID 1001)
+- **Working Directory**: `/liquibase`
+- **Entrypoint**: `docker-entrypoint.sh` with automatic MySQL driver installation
+
+### Key Components
+- **Liquibase**: Database migration tool (OSS: GitHub releases, Pro: repo.liquibase.com)
+- **LPM**: Liquibase Package Manager for extensions
+- **Default Config**: `liquibase.docker.properties` sets headless mode
+
+### Version Management
+- Liquibase versions are controlled via `LIQUIBASE_VERSION` (OSS) and `LIQUIBASE_PRO_VERSION` (Pro) ARGs
+- SHA256 checksums are validated for security
+- LPM version is specified via `LPM_VERSION` ARG
+
+## Environment Variables
+
+### Database Connection
+- `LIQUIBASE_COMMAND_URL`: JDBC connection string
+- `LIQUIBASE_COMMAND_USERNAME`: Database username
+- `LIQUIBASE_COMMAND_PASSWORD`: Database password
+- `LIQUIBASE_COMMAND_CHANGELOG_FILE`: Path to changelog file
+
+### Pro Features (DockerfilePro only)
+- `LIQUIBASE_LICENSE_KEY`: Required for Pro features
+- `LIQUIBASE_PRO_POLICY_CHECKS_ENABLED`: Enable policy checks
+- `LIQUIBASE_PRO_QUALITY_CHECKS_ENABLED`: Enable quality checks
+
+### Special Options
+- `INSTALL_MYSQL=true`: Auto-install MySQL driver at runtime
+- `LIQUIBASE_HOME=/liquibase`: Liquibase installation directory
+- `DOCKER_LIQUIBASE=true`: Marker for Docker environment
+
+## Extending Images
+
+### Adding Database Drivers
+```dockerfile
+FROM liquibase/liquibase:latest
+RUN lpm add mysql --global
+```
+
+### Adding Tools (e.g., AWS CLI)
+```dockerfile
+FROM liquibase/liquibase:latest
+USER root
+RUN apt-get update && apt-get install -y awscli
+USER liquibase
+```
+
+## Maven Configuration
+
+The `pom.xml` is minimal and used for build processes. The repository primarily uses Docker for builds rather than Maven.

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@ RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquiba
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
     
-ARG LPM_VERSION=0.2.9
-ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
-ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
+ARG LPM_VERSION=0.2.10
+ARG LPM_SHA256=3a47a733e4bf203f9d09ff400ff34146aacac79bd2d192fa0cd2ba3e6312f8d3
+ARG LPM_SHA256_ARM=5f63a39b0774b372f64189f1e332c70098a51e55bc0f4c442a86753e8e8a0978
     
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Container Image"

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -26,9 +26,9 @@ RUN set -x && \
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
     
-ARG LPM_VERSION=0.2.9
-ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
-ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
+ARG LPM_VERSION=0.2.10
+ARG LPM_SHA256=3a47a733e4bf203f9d09ff400ff34146aacac79bd2d192fa0cd2ba3e6312f8d3
+ARG LPM_SHA256_ARM=5f63a39b0774b372f64189f1e332c70098a51e55bc0f4c442a86753e8e8a0978
 
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Container Image (Alpine)"

--- a/DockerfilePro
+++ b/DockerfilePro
@@ -30,9 +30,9 @@ RUN wget -q -O liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz "https://repo.liqui
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
     
-ARG LPM_VERSION=0.2.9
-ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
-ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
+ARG LPM_VERSION=0.2.10
+ARG LPM_SHA256=3a47a733e4bf203f9d09ff400ff34146aacac79bd2d192fa0cd2ba3e6312f8d3
+ARG LPM_SHA256_ARM=5f63a39b0774b372f64189f1e332c70098a51e55bc0f4c442a86753e8e8a0978
 
 # Download and Install lpm
 RUN apt-get update && \

--- a/DockerfilePro
+++ b/DockerfilePro
@@ -29,7 +29,29 @@ RUN wget -q -O liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz "https://repo.liqui
     ln -s /liquibase/liquibase /usr/local/bin/liquibase && \
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
+    
+ARG LPM_VERSION=0.2.9
+ARG LPM_SHA256=b9caecd34c98a6c19a2bc582e8064aff5251c5f1adbcd100d3403c5eceb5373a
+ARG LPM_SHA256_ARM=0adb3a96d7384b4da549979bf00217a8914f0df37d1ed8fdb1b4a4baebfa104c
 
+# Download and Install lpm
+RUN apt-get update && \
+    apt-get -yqq install unzip --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir /liquibase/bin && \
+    arch="$(dpkg --print-architecture)" && \
+    case "$arch" in \
+    amd64)  DOWNLOAD_ARCH=""  ;; \
+    arm64)  DOWNLOAD_ARCH="-arm64" && LPM_SHA256=$LPM_SHA256_ARM ;; \
+    *) echo >&2 "error: unsupported architecture '$arch'" && exit 1 ;; \
+    esac && wget -q -O lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${LPM_VERSION}/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" && \
+    echo "$LPM_SHA256 *lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" | sha256sum -c - && \
+    unzip lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip -d bin/ && \
+    rm lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip && \
+    apt-get purge -y --auto-remove unzip && \
+    ln -s /liquibase/bin/lpm /usr/local/bin/lpm && \
+    lpm --version
+    
 # Set LIQUIBASE_HOME environment variable
 ENV LIQUIBASE_HOME=/liquibase
 # Marker which indicates this is a Liquibase docker container


### PR DESCRIPTION
## Summary

This PR addresses the issue where LPM (Liquibase Package Manager) was mistakenly not included in the Liquibase Pro Docker image during previous changes.

## Changes Made

- **DockerfilePro**: Added LPM installation with proper SHA256 validation for both amd64 and arm64 architectures
- **create-release.yml workflow**: Fixed LPM SHA updates in both OSS and Pro release workflows:
  - Added missing LPM SHA256 updates for Pro releases (DockerfilePro)
  - Uncommented ARM SHA256 updates for OSS releases (Dockerfile, Dockerfile.alpine)

## Technical Details

- LPM version 0.2.9 is now installed in the Pro image with proper checksum validation
- The release workflow now consistently updates LPM checksums for all Docker images when new versions are released
- This ensures the Pro image has the same LPM capabilities as the OSS image

## Testing

The changes ensure that:
- LPM is available in the Pro Docker image at `/liquibase/bin/lpm`
- Both amd64 and arm64 architectures are supported
- SHA256 checksums are properly validated for security
- Release workflows will correctly update LPM versions across all images

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>