### PR TITLE
DAT-20322: update Docker pull commands to use scarf URLs

### DIFF
--- a/README-pro.md
+++ b/README-pro.md
@@ -76,14 +76,14 @@ docker pull ecr.liquibase.com/liquibase/liquibase-pro
 
 ```bash
 # Latest
-docker pull docker.liquibase.com/liquibase-pro:latest
-docker pull ghcr.liquibase.com/liquibase-ghcr/liquibase-pro:latest
-docker pull public.ecr.liquibase.com/liquibase-ecr/liquibase-pro:latest
+docker pull docker.liquibase.com/liquibase/liquibase-pro:latest
+docker pull ghcr.liquibase.com/liquibase-pro:latest
+docker pull ecr.liquibase.com/liquibase-pro:latest
 
 # Specific version (example: 4.32.0)
-docker pull docker.liquibase.com/liquibase-pro:4.32.0
-docker pull ghcr.liquibase.com/liquibase-ghcr/liquibase-pro:4.32.0
-docker pull public.ecr.liquibase.com/liquibase-ecr/liquibase-pro:4.32.0
+docker pull docker.liquibase.com/liquibase/liquibase-pro:4.32.0
+docker pull ghcr.liquibase.com/liquibase-pro:4.32.0
+docker pull ecr.liquibase.com/liquibase-pro:4.32.0
 ```
 
 For any questions or support, please visit our [Liquibase Community Forum](https://forum.liquibase.org/).


### PR DESCRIPTION
This pull request updates the `README-pro.md` file to reflect changes in the Docker image repository URLs for Liquibase Pro. The updates ensure consistency and accuracy in the documentation by replacing outdated URLs with the new ones.

Updates to Docker image repository URLs:

* Updated default Docker Hub URL from `liquibase/liquibase-pro` to `docker.liquibase.com/liquibase/liquibase-pro`.
* Updated GitHub Container Registry URL from `ghcr.io/liquibase/liquibase-pro` to `ghcr.liquibase.com/liquibase/liquibase-pro`.
* Updated Amazon ECR Public URL from `public.ecr.aws/liquibase/liquibase-pro` to `public.ecr.liquibase.com/liquibase/liquibase-pro`. [[1]](diffhunk://#diff-6df2dddab882f1203c08bb04ef702472eb9fb4ff5caa590cae661a0e89dd901eL64-R70) [[2]](diffhunk://#diff-6df2dddab882f1203c08bb04ef702472eb9fb4ff5caa590cae661a0e89dd901eL79-R86)