### PR TITLE
DAT-18031: Trivy Scan of Published Images

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -19,151 +19,151 @@ permissions:
   contents: read
 
 jobs:
-  # trivy:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       image: [ 
-  #         {dockerfile: Dockerfile, name: liquibase/liquibase, suffix: ""},
-  #         {dockerfile: Dockerfile.alpine, name: liquibase/liquibase, suffix: "-alpine"},
-  #         {dockerfile: DockerfilePro, name: liquibase/liquibase-pro, suffix: "-pro"},
-  #         ]
-  #   permissions:
-  #     contents: read # for actions/checkout to fetch code
-  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-  #   name: Trivy
-  #   runs-on: "ubuntu-22.04"
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  trivy:
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [ 
+          {dockerfile: Dockerfile, name: liquibase/liquibase, suffix: ""},
+          {dockerfile: Dockerfile.alpine, name: liquibase/liquibase, suffix: "-alpine"},
+          {dockerfile: DockerfilePro, name: liquibase/liquibase-pro, suffix: "-pro"},
+          ]
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Trivy
+    runs-on: "ubuntu-22.04"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: Build ${{ matrix.image.name }}${{ matrix.image.suffix }} from Dockerfile
-  #       run: |
-  #         docker build -f ${{ matrix.image.dockerfile }} -t ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }} .
+      - name: Build ${{ matrix.image.name }}${{ matrix.image.suffix }} from Dockerfile
+        run: |
+          docker build -f ${{ matrix.image.dockerfile }} -t ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }} .
 
-  #     - name: Run Trivy vulnerability scanner
-  #       uses: aquasecurity/trivy-action@0.31.0
-  #       with:
-  #         image-ref: '${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}'
-  #         vuln-type: 'os,library'
-  #         format: 'sarif'
-  #         output: 'trivy-results.sarif'
-  #         severity: 'HIGH,CRITICAL'
-  #         exit-code: '1'
-  #         limit-severities-for-sarif: true
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.31.0
+        with:
+          image-ref: '${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}'
+          vuln-type: 'os,library'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+          limit-severities-for-sarif: true
 
-  #     - name: Notify Slack on Build Failure
-  #       if: failure()
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_COLOR: 'failure'
-  #         SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
-  #         SLACK_TITLE: "❌ ${{ github.repository }} ❌ Trivy failed on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
-  #         SLACK_USERNAME: liquibot
-  #         SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
-  #         SLACK_ICON_EMOJI: ":whale:"
-  #         SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}"
-  #         SLACK_LINK_NAMES: true
+      - name: Notify Slack on Build Failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'failure'
+          SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
+          SLACK_TITLE: "❌ ${{ github.repository }} ❌ Trivy failed on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
+          SLACK_USERNAME: liquibot
+          SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
+          SLACK_ICON_EMOJI: ":whale:"
+          SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}"
+          SLACK_LINK_NAMES: true
 
-  #     - name: Upload Trivy scan results to GitHub Security tab
-  #       if: always()
-  #       uses: github/codeql-action/upload-sarif@v3
-  #       with:
-  #         sarif_file: 'trivy-results.sarif'
-  #         category: '${{ matrix.image.name }}${{ matrix.image.suffix }}'
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: '${{ matrix.image.name }}${{ matrix.image.suffix }}'
 
-  #     - name: Generate Security Report
-  #       if: always()
-  #       uses: rsdmike/github-security-report-action@v3.0.4
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         outputDir: ./reports/trivy${{ matrix.image.suffix }}/
-  #         sarifReportDir: .
+      - name: Generate Security Report
+        if: always()
+        uses: rsdmike/github-security-report-action@v3.0.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          outputDir: ./reports/trivy${{ matrix.image.suffix }}/
+          sarifReportDir: .
 
-  #     - name: Upload Security Report
-  #       if: always()
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: security-report-trivy${{ matrix.image.suffix }}
-  #         path: ./reports/trivy${{ matrix.image.suffix }}/summary.pdf
+      - name: Upload Security Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-report-trivy${{ matrix.image.suffix }}
+          path: ./reports/trivy${{ matrix.image.suffix }}/summary.pdf
 
 
-  # scout:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       image: [ 
-  #         {dockerfile: Dockerfile, name: liquibase/liquibase, suffix: ""},
-  #         {dockerfile: Dockerfile.alpine, name: liquibase/liquibase, suffix: "-alpine"},
-  #         {dockerfile: DockerfilePro, name: liquibase/liquibase-pro, suffix: "-pro"},
-  #         ]
-  #   permissions:
-  #     contents: read # for actions/checkout to fetch code
-  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-  #     pull-requests: write # for docker/scout-action to write comments on pull requests
-  #   name: Scout
-  #   runs-on: "ubuntu-22.04"
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  scout:
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [ 
+          {dockerfile: Dockerfile, name: liquibase/liquibase, suffix: ""},
+          {dockerfile: Dockerfile.alpine, name: liquibase/liquibase, suffix: "-alpine"},
+          {dockerfile: DockerfilePro, name: liquibase/liquibase-pro, suffix: "-pro"},
+          ]
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+      pull-requests: write # for docker/scout-action to write comments on pull requests
+    name: Scout
+    runs-on: "ubuntu-22.04"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: Build ${{ matrix.image.name }}${{ matrix.image.suffix }} from Dockerfile
-  #       run: |
-  #         docker build -f ${{ matrix.image.dockerfile }} -t ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }} .
+      - name: Build ${{ matrix.image.name }}${{ matrix.image.suffix }} from Dockerfile
+        run: |
+          docker build -f ${{ matrix.image.dockerfile }} -t ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }} .
 
-  #     - uses: docker/login-action@v3
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  #     - name: Docker Scout
-  #       uses: docker/scout-action@v1.18.1
-  #       with:
-  #         command: cves
-  #         image: '${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}'
-  #         github-token: ${{ secrets.GITHUB_TOKEN }}
-  #         write-comment: true
-  #         sarif-file: 'scout-results.sarif'
-  #         summary: true
-  #         exit-code: true
-  #         only-severities: "critical,high"
+      - name: Docker Scout
+        uses: docker/scout-action@v1.18.1
+        with:
+          command: cves
+          image: '${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          write-comment: true
+          sarif-file: 'scout-results.sarif'
+          summary: true
+          exit-code: true
+          only-severities: "critical,high"
 
-  #     - name: Notify Slack on Build Failure
-  #       if: failure()
-  #       uses: rtCamp/action-slack-notify@v2
-  #       env:
-  #         SLACK_COLOR: 'failure'
-  #         SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
-  #         SLACK_TITLE: "❌ ${{ github.repository }} ❌ Docker Scout failed on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
-  #         SLACK_USERNAME: liquibot
-  #         SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
-  #         SLACK_ICON_EMOJI: ":whale:"
-  #         SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}"
-  #         SLACK_LINK_NAMES: true
+      - name: Notify Slack on Build Failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'failure'
+          SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
+          SLACK_TITLE: "❌ ${{ github.repository }} ❌ Docker Scout failed on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
+          SLACK_USERNAME: liquibot
+          SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
+          SLACK_ICON_EMOJI: ":whale:"
+          SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}"
+          SLACK_LINK_NAMES: true
 
-  #     - name: Upload Scout scan results to GitHub Security tab
-  #       if: always()
-  #       uses: github/codeql-action/upload-sarif@v3
-  #       with:
-  #         sarif_file: 'scout-results.sarif'
-  #         category: '${{ matrix.image.name }}${{ matrix.image.suffix }}'
+      - name: Upload Scout scan results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'scout-results.sarif'
+          category: '${{ matrix.image.name }}${{ matrix.image.suffix }}'
 
-  #     - name: Generate Security Report
-  #       if: always()
-  #       uses: rsdmike/github-security-report-action@v3.0.4
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         outputDir: ./reports/scout${{ matrix.image.suffix }}/
-  #         sarifReportDir: .
+      - name: Generate Security Report
+        if: always()
+        uses: rsdmike/github-security-report-action@v3.0.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          outputDir: ./reports/scout${{ matrix.image.suffix }}/
+          sarifReportDir: .
 
-  #     - name: Upload Security Report
-  #       if: always()
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: security-report-scout${{ matrix.image.suffix }}
-  #         path: ./reports/scout${{ matrix.image.suffix }}/summary.pdf
+      - name: Upload Security Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-report-scout${{ matrix.image.suffix }}
+          path: ./reports/scout${{ matrix.image.suffix }}/summary.pdf
 
   trivy-published:
     name: Trivy Scan Published Images
@@ -179,13 +179,13 @@ jobs:
           # Docker Hub
           {name: liquibase/liquibase, tag: 'latest', registry: 'docker.io'},
           {name: liquibase/liquibase, tag: 'alpine', registry: 'docker.io'},
-          {name: liquibase/liquibase-pro, tag: 'pro', registry: 'docker.io'},
+          {name: liquibase/liquibase-pro, tag: 'latest', registry: 'docker.io'},
           # GHCR
           {name: ghcr.io/liquibase/liquibase, tag: 'latest', registry: 'ghcr.io'},
-          {name: ghcr.io/liquibase/liquibase-pro, tag: 'pro', registry: 'ghcr.io'},
+          {name: ghcr.io/liquibase/liquibase-pro, tag: 'latest', registry: 'ghcr.io'},
           # ECR Public
           {name: public.ecr.aws/liquibase/liquibase, tag: 'latest', registry: 'ecr'},
-          {name: public.ecr.aws/liquibase/liquibase-pro, tag: 'pro', registry: 'ecr'},
+          {name: public.ecr.aws/liquibase/liquibase-pro, tag: 'latest', registry: 'ecr'},
         ]
     steps:
       - name: Login to GHCR
@@ -228,18 +228,18 @@ jobs:
           echo "Vulnerabilities were found in the scanned image."
           echo "See details in the GitHub Security tab: https://github.com/liquibase/docker/security/code-scanning"
 
-      # - name: Notify Slack on Published Image Scan Failure
-      #   if: failure()
-      #   uses: rtCamp/action-slack-notify@v2
-      #   env:
-      #     SLACK_COLOR: 'failure'
-      #     SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
-      #     SLACK_TITLE: "❌ ${{ github.repository }} ❌ Trivy published image scan failed for ${{ matrix.image.name }}:${{ matrix.image.tag }} on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
-      #     SLACK_USERNAME: liquibot
-      #     SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
-      #     SLACK_ICON_EMOJI: ":whale:"
-      #     SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}:${{ matrix.image.tag }}"
-      #     SLACK_LINK_NAMES: true
+      - name: Notify Slack on Published Image Scan Failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'failure'
+          SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
+          SLACK_TITLE: "❌ ${{ github.repository }} ❌ Trivy published image scan failed for ${{ matrix.image.name }}:${{ matrix.image.tag }} on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
+          SLACK_USERNAME: liquibot
+          SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
+          SLACK_ICON_EMOJI: ":whale:"
+          SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}:${{ matrix.image.tag }}"
+          SLACK_LINK_NAMES: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -254,5 +254,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: security-report-trivy-published-${{ steps.sanitize.outputs.sanitized }}-${{ matrix.image.tag }}
+          name: security-report-trivy-published-${{ matrix.image.registry }}-${{ steps.sanitize.outputs.sanitized }}-${{ matrix.image.tag }}
           path: trivy-published-results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -19,151 +19,151 @@ permissions:
   contents: read
 
 jobs:
-  trivy:
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [ 
-          {dockerfile: Dockerfile, name: liquibase/liquibase, suffix: ""},
-          {dockerfile: Dockerfile.alpine, name: liquibase/liquibase, suffix: "-alpine"},
-          {dockerfile: DockerfilePro, name: liquibase/liquibase-pro, suffix: "-pro"},
-          ]
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    name: Trivy
-    runs-on: "ubuntu-22.04"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  # trivy:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       image: [ 
+  #         {dockerfile: Dockerfile, name: liquibase/liquibase, suffix: ""},
+  #         {dockerfile: Dockerfile.alpine, name: liquibase/liquibase, suffix: "-alpine"},
+  #         {dockerfile: DockerfilePro, name: liquibase/liquibase-pro, suffix: "-pro"},
+  #         ]
+  #   permissions:
+  #     contents: read # for actions/checkout to fetch code
+  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+  #   name: Trivy
+  #   runs-on: "ubuntu-22.04"
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
 
-      - name: Build ${{ matrix.image.name }}${{ matrix.image.suffix }} from Dockerfile
-        run: |
-          docker build -f ${{ matrix.image.dockerfile }} -t ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }} .
+  #     - name: Build ${{ matrix.image.name }}${{ matrix.image.suffix }} from Dockerfile
+  #       run: |
+  #         docker build -f ${{ matrix.image.dockerfile }} -t ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }} .
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.31.0
-        with:
-          image-ref: '${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}'
-          vuln-type: 'os,library'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'HIGH,CRITICAL'
-          exit-code: '1'
-          limit-severities-for-sarif: true
+  #     - name: Run Trivy vulnerability scanner
+  #       uses: aquasecurity/trivy-action@0.31.0
+  #       with:
+  #         image-ref: '${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}'
+  #         vuln-type: 'os,library'
+  #         format: 'sarif'
+  #         output: 'trivy-results.sarif'
+  #         severity: 'HIGH,CRITICAL'
+  #         exit-code: '1'
+  #         limit-severities-for-sarif: true
 
-      - name: Notify Slack on Build Failure
-        if: failure()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_COLOR: 'failure'
-          SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
-          SLACK_TITLE: "❌ ${{ github.repository }} ❌ Trivy failed on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
-          SLACK_USERNAME: liquibot
-          SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
-          SLACK_ICON_EMOJI: ":whale:"
-          SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}"
-          SLACK_LINK_NAMES: true
+  #     - name: Notify Slack on Build Failure
+  #       if: failure()
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_COLOR: 'failure'
+  #         SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
+  #         SLACK_TITLE: "❌ ${{ github.repository }} ❌ Trivy failed on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
+  #         SLACK_USERNAME: liquibot
+  #         SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
+  #         SLACK_ICON_EMOJI: ":whale:"
+  #         SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}"
+  #         SLACK_LINK_NAMES: true
 
-      - name: Upload Trivy scan results to GitHub Security tab
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'trivy-results.sarif'
-          category: '${{ matrix.image.name }}${{ matrix.image.suffix }}'
+  #     - name: Upload Trivy scan results to GitHub Security tab
+  #       if: always()
+  #       uses: github/codeql-action/upload-sarif@v3
+  #       with:
+  #         sarif_file: 'trivy-results.sarif'
+  #         category: '${{ matrix.image.name }}${{ matrix.image.suffix }}'
 
-      - name: Generate Security Report
-        if: always()
-        uses: rsdmike/github-security-report-action@v3.0.4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          outputDir: ./reports/trivy${{ matrix.image.suffix }}/
-          sarifReportDir: .
+  #     - name: Generate Security Report
+  #       if: always()
+  #       uses: rsdmike/github-security-report-action@v3.0.4
+  #       with:
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         outputDir: ./reports/trivy${{ matrix.image.suffix }}/
+  #         sarifReportDir: .
 
-      - name: Upload Security Report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: security-report-trivy${{ matrix.image.suffix }}
-          path: ./reports/trivy${{ matrix.image.suffix }}/summary.pdf
+  #     - name: Upload Security Report
+  #       if: always()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: security-report-trivy${{ matrix.image.suffix }}
+  #         path: ./reports/trivy${{ matrix.image.suffix }}/summary.pdf
 
 
-  scout:
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [ 
-          {dockerfile: Dockerfile, name: liquibase/liquibase, suffix: ""},
-          {dockerfile: Dockerfile.alpine, name: liquibase/liquibase, suffix: "-alpine"},
-          {dockerfile: DockerfilePro, name: liquibase/liquibase-pro, suffix: "-pro"},
-          ]
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-      pull-requests: write # for docker/scout-action to write comments on pull requests
-    name: Scout
-    runs-on: "ubuntu-22.04"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  # scout:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       image: [ 
+  #         {dockerfile: Dockerfile, name: liquibase/liquibase, suffix: ""},
+  #         {dockerfile: Dockerfile.alpine, name: liquibase/liquibase, suffix: "-alpine"},
+  #         {dockerfile: DockerfilePro, name: liquibase/liquibase-pro, suffix: "-pro"},
+  #         ]
+  #   permissions:
+  #     contents: read # for actions/checkout to fetch code
+  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+  #     actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+  #     pull-requests: write # for docker/scout-action to write comments on pull requests
+  #   name: Scout
+  #   runs-on: "ubuntu-22.04"
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
 
-      - name: Build ${{ matrix.image.name }}${{ matrix.image.suffix }} from Dockerfile
-        run: |
-          docker build -f ${{ matrix.image.dockerfile }} -t ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }} .
+  #     - name: Build ${{ matrix.image.name }}${{ matrix.image.suffix }} from Dockerfile
+  #       run: |
+  #         docker build -f ${{ matrix.image.dockerfile }} -t ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }} .
 
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+  #     - uses: docker/login-action@v3
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Docker Scout
-        uses: docker/scout-action@v1.18.1
-        with:
-          command: cves
-          image: '${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          write-comment: true
-          sarif-file: 'scout-results.sarif'
-          summary: true
-          exit-code: true
-          only-severities: "critical,high"
+  #     - name: Docker Scout
+  #       uses: docker/scout-action@v1.18.1
+  #       with:
+  #         command: cves
+  #         image: '${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}'
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #         write-comment: true
+  #         sarif-file: 'scout-results.sarif'
+  #         summary: true
+  #         exit-code: true
+  #         only-severities: "critical,high"
 
-      - name: Notify Slack on Build Failure
-        if: failure()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_COLOR: 'failure'
-          SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
-          SLACK_TITLE: "❌ ${{ github.repository }} ❌ Docker Scout failed on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
-          SLACK_USERNAME: liquibot
-          SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
-          SLACK_ICON_EMOJI: ":whale:"
-          SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}"
-          SLACK_LINK_NAMES: true
+  #     - name: Notify Slack on Build Failure
+  #       if: failure()
+  #       uses: rtCamp/action-slack-notify@v2
+  #       env:
+  #         SLACK_COLOR: 'failure'
+  #         SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
+  #         SLACK_TITLE: "❌ ${{ github.repository }} ❌ Docker Scout failed on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
+  #         SLACK_USERNAME: liquibot
+  #         SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
+  #         SLACK_ICON_EMOJI: ":whale:"
+  #         SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}"
+  #         SLACK_LINK_NAMES: true
 
-      - name: Upload Scout scan results to GitHub Security tab
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: 'scout-results.sarif'
-          category: '${{ matrix.image.name }}${{ matrix.image.suffix }}'
+  #     - name: Upload Scout scan results to GitHub Security tab
+  #       if: always()
+  #       uses: github/codeql-action/upload-sarif@v3
+  #       with:
+  #         sarif_file: 'scout-results.sarif'
+  #         category: '${{ matrix.image.name }}${{ matrix.image.suffix }}'
 
-      - name: Generate Security Report
-        if: always()
-        uses: rsdmike/github-security-report-action@v3.0.4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          outputDir: ./reports/scout${{ matrix.image.suffix }}/
-          sarifReportDir: .
+  #     - name: Generate Security Report
+  #       if: always()
+  #       uses: rsdmike/github-security-report-action@v3.0.4
+  #       with:
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         outputDir: ./reports/scout${{ matrix.image.suffix }}/
+  #         sarifReportDir: .
 
-      - name: Upload Security Report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: security-report-scout${{ matrix.image.suffix }}
-          path: ./reports/scout${{ matrix.image.suffix }}/summary.pdf
+  #     - name: Upload Security Report
+  #       if: always()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: security-report-scout${{ matrix.image.suffix }}
+  #         path: ./reports/scout${{ matrix.image.suffix }}/summary.pdf
 
   trivy-published:
     name: Trivy Scan Published Images

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -164,3 +164,85 @@ jobs:
         with:
           name: security-report-scout${{ matrix.image.suffix }}
           path: ./reports/scout${{ matrix.image.suffix }}/summary.pdf
+
+  trivy-published:
+    name: Trivy Scan Published Images
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [
+          # Docker Hub
+          {name: liquibase/liquibase, tag: 'latest', registry: 'docker.io'},
+          {name: liquibase/liquibase, tag: 'alpine', registry: 'docker.io'},
+          {name: liquibase/liquibase-pro, tag: 'pro', registry: 'docker.io'},
+          # GHCR
+          {name: ghcr.io/liquibase/liquibase, tag: 'latest', registry: 'ghcr.io'},
+          {name: ghcr.io/liquibase/liquibase, tag: 'alpine', registry: 'ghcr.io'},
+          {name: ghcr.io/liquibase/liquibase-pro, tag: 'pro', registry: 'ghcr.io'},
+          # ECR Public
+          {name: public.ecr.aws/liquibase/liquibase, tag: 'latest', registry: 'ecr'},
+          {name: public.ecr.aws/liquibase/liquibase, tag: 'alpine', registry: 'ecr'},
+          {name: public.ecr.aws/liquibase/liquibase-pro, tag: 'pro', registry: 'ecr'},
+        ]
+    steps:
+      - name: Login to GHCR
+        if: matrix.image.registry == 'ghcr.io'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Amazon ECR Registry
+        if: matrix.image.registry == 'ecr'
+        uses: docker/login-action@v3
+        env:
+          AWS_REGION: us-east-1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.PUBLIC_ECR_ACCESS_KEY_ID }}
+          password: ${{ secrets.PUBLIC_ECR_SECRET_ACCESS_KEY }}
+
+      - name: Pull published image ${{ matrix.image.name }}:${{ matrix.image.tag }}
+        run: docker pull ${{ matrix.image.name }}:${{ matrix.image.tag }}
+
+      - name: Run Trivy CVE vulnerability scanner on published image
+        # This step scans for CVE vulnerabilities (OS and libraries)
+        uses: aquasecurity/trivy-action@0.31.0
+        with:
+          image-ref: '${{ matrix.image.name }}:${{ matrix.image.tag }}'
+          vuln-type: 'os,library'
+          scanners: 'vuln'
+          format: 'sarif'
+          output: 'trivy-published-results.sarif'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+          limit-severities-for-sarif: true
+
+      - name: Notify Slack on Published Image Scan Failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'failure'
+          SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
+          SLACK_TITLE: "❌ ${{ github.repository }} ❌ Trivy published image scan failed for ${{ matrix.image.name }}:${{ matrix.image.tag }} on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
+          SLACK_USERNAME: liquibot
+          SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
+          SLACK_ICON_EMOJI: ":whale:"
+          SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}:${{ matrix.image.tag }}"
+          SLACK_LINK_NAMES: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-published-results.sarif'
+          category: 'published-${{ matrix.image.name }}-${{ matrix.image.tag }}'
+
+      - name: Upload Trivy Published Security Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-report-trivy-published-${{ matrix.image.name }}-${{ matrix.image.tag }}
+          path: trivy-published-results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -182,11 +182,9 @@ jobs:
           {name: liquibase/liquibase-pro, tag: 'pro', registry: 'docker.io'},
           # GHCR
           {name: ghcr.io/liquibase/liquibase, tag: 'latest', registry: 'ghcr.io'},
-          {name: ghcr.io/liquibase/liquibase, tag: 'alpine', registry: 'ghcr.io'},
           {name: ghcr.io/liquibase/liquibase-pro, tag: 'pro', registry: 'ghcr.io'},
           # ECR Public
           {name: public.ecr.aws/liquibase/liquibase, tag: 'latest', registry: 'ecr'},
-          {name: public.ecr.aws/liquibase/liquibase, tag: 'alpine', registry: 'ecr'},
           {name: public.ecr.aws/liquibase/liquibase-pro, tag: 'pro', registry: 'ecr'},
         ]
     steps:
@@ -213,7 +211,6 @@ jobs:
 
       - name: Run Trivy CVE vulnerability scanner on published image
         id: trivy_scan
-        continue-on-error: true
         uses: aquasecurity/trivy-action@0.31.0
         with:
           image-ref: '${{ matrix.image.name }}:${{ matrix.image.tag }}'
@@ -252,6 +249,7 @@ jobs:
           category: 'published-${{ matrix.image.name }}-${{ matrix.image.tag }}'
 
       - name: Set sanitized image name
+        if: always()
         id: sanitize
         run: echo "sanitized=${IMAGE_NAME//\//-}" >> $GITHUB_OUTPUT
         env:
@@ -265,7 +263,7 @@ jobs:
           path: trivy-published-results.sarif
 
       - name: Print Trivy vulnerabilities to log
-        if: steps.trivy_scan.outcome == 'failure'
+        if: steps.trivy_scan.outcome == 'failure' && always()
         run: |
           echo "\n==== Trivy Vulnerabilities (table format) ===="
           docker run --rm aquasec/trivy:0.49.1 image --severity HIGH,CRITICAL --format table ${{ matrix.image.name }}:${{ matrix.image.tag }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -168,6 +168,10 @@ jobs:
   trivy-published:
     name: Trivy Scan Published Images
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:
@@ -220,18 +224,18 @@ jobs:
           exit-code: '1'
           limit-severities-for-sarif: true
 
-      - name: Notify Slack on Published Image Scan Failure
-        if: failure()
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_COLOR: 'failure'
-          SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
-          SLACK_TITLE: "❌ ${{ github.repository }} ❌ Trivy published image scan failed for ${{ matrix.image.name }}:${{ matrix.image.tag }} on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
-          SLACK_USERNAME: liquibot
-          SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
-          SLACK_ICON_EMOJI: ":whale:"
-          SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}:${{ matrix.image.tag }}"
-          SLACK_LINK_NAMES: true
+      # - name: Notify Slack on Published Image Scan Failure
+      #   if: failure()
+      #   uses: rtCamp/action-slack-notify@v2
+      #   env:
+      #     SLACK_COLOR: 'failure'
+      #     SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
+      #     SLACK_TITLE: "❌ ${{ github.repository }} ❌ Trivy published image scan failed for ${{ matrix.image.name }}:${{ matrix.image.tag }} on branch ${{ github.ref_name }} for commit ${{ github.sha }} in repository ${{ github.repository }}"
+      #     SLACK_USERNAME: liquibot
+      #     SLACK_WEBHOOK: ${{ secrets.DOCKER_SLACK_WEBHOOK_URL }}
+      #     SLACK_ICON_EMOJI: ":whale:"
+      #     SLACK_FOOTER: "${{ github.repository }} - ${{ matrix.image.name }}:${{ matrix.image.tag }}"
+      #     SLACK_LINK_NAMES: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()
@@ -240,9 +244,15 @@ jobs:
           sarif_file: 'trivy-published-results.sarif'
           category: 'published-${{ matrix.image.name }}-${{ matrix.image.tag }}'
 
+      - name: Set sanitized image name
+        id: sanitize
+        run: echo "sanitized=${IMAGE_NAME//\//-}" >> $GITHUB_OUTPUT
+        env:
+          IMAGE_NAME: ${{ matrix.image.name }}
+
       - name: Upload Trivy Published Security Report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: security-report-trivy-published-${{ matrix.image.name }}-${{ matrix.image.tag }}
+          name: security-report-trivy-published-${{ steps.sanitize.outputs.sanitized }}-${{ matrix.image.tag }}
           path: trivy-published-results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -212,7 +212,8 @@ jobs:
         run: docker pull ${{ matrix.image.name }}:${{ matrix.image.tag }}
 
       - name: Run Trivy CVE vulnerability scanner on published image
-        # This step scans for CVE vulnerabilities (OS and libraries)
+        id: trivy_scan
+        continue-on-error: true
         uses: aquasecurity/trivy-action@0.31.0
         with:
           image-ref: '${{ matrix.image.name }}:${{ matrix.image.tag }}'
@@ -223,6 +224,12 @@ jobs:
           severity: 'HIGH,CRITICAL'
           exit-code: '1'
           limit-severities-for-sarif: true
+
+      - name: Echo if vulnerabilities found
+        if: steps.trivy_scan.outcome == 'failure'
+        run: |
+          echo "Vulnerabilities were found in the scanned image."
+          echo "See details in the GitHub Security tab: https://github.com/liquibase/docker/security/code-scanning"
 
       # - name: Notify Slack on Published Image Scan Failure
       #   if: failure()
@@ -256,3 +263,9 @@ jobs:
         with:
           name: security-report-trivy-published-${{ matrix.image.registry }}-${{ steps.sanitize.outputs.sanitized }}-${{ matrix.image.tag }}
           path: trivy-published-results.sarif
+
+      - name: Print Trivy vulnerabilities to log
+        if: steps.trivy_scan.outcome == 'failure'
+        run: |
+          echo "\n==== Trivy Vulnerabilities (table format) ===="
+          docker run --rm aquasec/trivy:0.49.1 image --severity HIGH,CRITICAL --format table ${{ matrix.image.name }}:${{ matrix.image.tag }}


### PR DESCRIPTION
This pull request introduces a new workflow to `.github/workflows/trivy.yml` for scanning published Docker images using Trivy for vulnerabilities. The workflow includes steps for logging into registries, pulling images, running scans, notifying on failures, and uploading results. 

### New Trivy Scan Workflow for Published Images:
* **Workflow addition**: Added a new job `trivy-published` to scan published Docker images across multiple registries (`docker.io`, `ghcr.io`, and `public.ecr.aws`) using Trivy.
* **Registry login**: Added steps to log into GitHub Container Registry (GHCR) and Amazon ECR for image access based on the matrix configuration.
* **Vulnerability scanning**: Integrated Trivy to scan images for `os` and `library` vulnerabilities, with results formatted in SARIF and filtered for `HIGH` and `CRITICAL` severity.
* **Failure notification**: Added Slack notifications for scan failures, providing detailed context about the failed job and triggering repository.
* **Results handling**: Uploaded SARIF scan results to the GitHub Security tab and as artifacts, and logged vulnerabilities in table format for visibility.
* https://github.com/liquibase/docker/actions/runs/15978593405/job/45067364648#step:10:60
<img width="1404" alt="Screenshot 2025-06-30 at 1 27 05 PM" src="https://github.com/user-attachments/assets/84d4b0d3-09af-476b-b8db-9a8a66752c2c" />
