### PR TITLE
DAT-20423 Automate QA Docker Image Creation for Branch Testing

### DIFF
--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -1,0 +1,116 @@
+name: Build QA Docker Images
+
+permissions:
+  contents: read
+  id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      liquibaseVersion:
+        description: "Liquibase Version (e.g., 4.33.0)"
+        required: true
+        type: string
+      buildLiquibaseQA:
+        description: "Build liquibase-qa (Dockerfile)"
+        type: boolean
+        default: true
+      buildLiquibaseAlpineQA:
+        description: "Build liquibase-qa-alpine (Dockerfile.alpine)"
+        type: boolean
+        default: true
+      buildLiquibaseProQA:
+        description: "Build liquibase-pro-qa (DockerfilePro)"
+        type: boolean
+        default: true
+
+jobs:
+  build-qa-docker:
+    name: "Build and Push QA Docker Images"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - dockerfile: Dockerfile
+            image_name: "liquibase-qa"
+            suffix: ""
+            condition: ${{ inputs.buildLiquibaseQA }}
+          - dockerfile: Dockerfile.alpine
+            image_name: "liquibase-qa-alpine"
+            suffix: "-alpine"
+            condition: ${{ inputs.buildLiquibaseAlpineQA }}
+          - dockerfile: DockerfilePro
+            image_name: "liquibase-pro-qa"
+            suffix: "-pro"
+            condition: ${{ inputs.buildLiquibaseProQA }}
+    steps:
+      - name: Skip if not selected
+        if: ${{ matrix.condition == false }}
+        run: |
+          echo "Skipping ${{ matrix.image_name }} - not selected for build"
+          exit 0
+
+      - name: Checkout code
+        if: ${{ matrix.condition == true }}
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        id: vault-secrets-liquibase
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
+      - name: Set up Docker Buildx
+        if: ${{ matrix.condition == true }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        if: ${{ matrix.condition == true }}
+        uses: docker/setup-qemu-action@v3
+
+      - name: Log in to internal Nexus Docker Registry
+        if: ${{ matrix.condition == true }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REPO_URL }}
+          username: ${{ env.REPO_USER }}
+          password: ${{ env.REPO_PASSWORD }}
+
+      - name: Build and push Docker image
+        if: ${{ matrix.condition == true }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          tags: |
+            ${{ env.REPO_URL }}/${{ matrix.image_name }}:${{ inputs.liquibaseVersion }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/liquibase/docker
+            org.opencontainers.image.description=Liquibase QA Container Image${{ matrix.suffix }}
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=Liquibase
+            org.opencontainers.image.version=${{ inputs.liquibaseVersion }}
+            org.opencontainers.image.documentation=https://docs.liquibase.com
+          annotations: |
+            org.opencontainers.image.source=https://github.com/liquibase/docker
+            org.opencontainers.image.description=Liquibase QA Container Image${{ matrix.suffix }}
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=Liquibase
+            org.opencontainers.image.version=${{ inputs.liquibaseVersion }}
+            org.opencontainers.image.documentation=https://docs.liquibase.com
+
+      - name: Image build summary
+        if: ${{ matrix.condition == true }}
+        run: |
+          echo "Successfully built and pushed: ${{ env.REPO_URL }}/${{ matrix.image_name }}:${{ inputs.liquibaseVersion }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@ RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquiba
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
     
-ARG LPM_VERSION=0.2.10
-ARG LPM_SHA256=3a47a733e4bf203f9d09ff400ff34146aacac79bd2d192fa0cd2ba3e6312f8d3
-ARG LPM_SHA256_ARM=5f63a39b0774b372f64189f1e332c70098a51e55bc0f4c442a86753e8e8a0978
+ARG LPM_VERSION=0.2.11
+ARG LPM_SHA256=d07d1373446d2a9f11010649d705eba2ebefc23aedffec58d4d0a117c9a195b7
+ARG LPM_SHA256_ARM=77c8cf8369ad07ed536c3b4c352e40815f32f89b111cafabf8e3cfc102d912f8
     
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Container Image"

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -26,9 +26,9 @@ RUN set -x && \
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
     
-ARG LPM_VERSION=0.2.10
-ARG LPM_SHA256=3a47a733e4bf203f9d09ff400ff34146aacac79bd2d192fa0cd2ba3e6312f8d3
-ARG LPM_SHA256_ARM=5f63a39b0774b372f64189f1e332c70098a51e55bc0f4c442a86753e8e8a0978
+ARG LPM_VERSION=0.2.11
+ARG LPM_SHA256=d07d1373446d2a9f11010649d705eba2ebefc23aedffec58d4d0a117c9a195b7
+ARG LPM_SHA256_ARM=77c8cf8369ad07ed536c3b4c352e40815f32f89b111cafabf8e3cfc102d912f8
 
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Container Image (Alpine)"

--- a/DockerfilePro
+++ b/DockerfilePro
@@ -30,9 +30,9 @@ RUN wget -q -O liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz "https://repo.liqui
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
     
-ARG LPM_VERSION=0.2.10
-ARG LPM_SHA256=3a47a733e4bf203f9d09ff400ff34146aacac79bd2d192fa0cd2ba3e6312f8d3
-ARG LPM_SHA256_ARM=5f63a39b0774b372f64189f1e332c70098a51e55bc0f4c442a86753e8e8a0978
+ARG LPM_VERSION=0.2.11
+ARG LPM_SHA256=d07d1373446d2a9f11010649d705eba2ebefc23aedffec58d4d0a117c9a195b7
+ARG LPM_SHA256_ARM=77c8cf8369ad07ed536c3b4c352e40815f32f89b111cafabf8e3cfc102d912f8
 
 # Download and Install lpm
 RUN apt-get update && \


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to build and push QA Docker images, along with updates to the `LPM_VERSION` and associated SHA256 values across multiple Dockerfiles. These changes aim to streamline the Docker image build process and ensure the use of the latest version of the Liquibase Package Manager (LPM).

### New Workflow for QA Docker Images:
* [`.github/workflows/build-qa-docker.yml`](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dR1-R116): Added a GitHub Actions workflow to build and push QA Docker images (`liquibase-qa`, `liquibase-qa-alpine`, and `liquibase-pro-qa`) with support for workflow dispatch inputs and matrix builds. The workflow includes steps for AWS credentials configuration, secret retrieval, Docker setup, and image building/pushing.

### Updates to Dockerfiles:
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L23-R25): Updated `LPM_VERSION` to `0.2.11` and updated SHA256 values (`LPM_SHA256` and `LPM_SHA256_ARM`) to match the new version.
* [`Dockerfile.alpine`](diffhunk://#diff-f865864730d7062c04cc13b1b85ba03ed5dbef3fa02fcb50b87d9117d0af1f4eL29-R31): Updated `LPM_VERSION` to `0.2.11` and updated SHA256 values for the Alpine-based image.
* [`DockerfilePro`](diffhunk://#diff-c7d3cd1d899e2b9d2304f2c2c463d4ac2c205be82b76124dfece409cc8ccf74eL33-R35): Updated `LPM_VERSION` to `0.2.11` and updated SHA256 values for the Pro version image.