### PR TITLE
DAT-20280: Add trigger for AWS Marketplace listing that runs in aws-license-service repo

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -542,3 +542,14 @@ jobs:
 
       - name: Adding Official Docker PR to job summary
         run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY
+
+  trigger-aws-marketplace-listing:
+    runs-on: ubuntu-latest
+    needs: [ update-dockerfiles, setup-update-draft-build ]
+    steps:
+      - name: Trigger AWS Marketplace Listing
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: trigger-aws-marketplace-listing
+          repository: liquibase/liquibase-aws-license-service


### PR DESCRIPTION
This pull request adds a new workflow job to the `.github/workflows/create-release.yml` file to automate the process of triggering an AWS Marketplace listing update after the Dockerfiles and draft build have been updated.

**Automation and integration:**

* Added a new `trigger-aws-marketplace-listing` job that runs after `update-dockerfiles` and `setup-update-draft-build`, using the `peter-evans/repository-dispatch@v3` action to dispatch an event to the `liquibase/liquibase-aws-license-service` repository for AWS Marketplace listing updates.