### PR TITLE
✨ DAT-20655: Add Liquibase Secure support with Dockerfile and Compose configuration

### DIFF
--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -18,12 +18,13 @@ on:
         required: true
         type: choice
         options:
-          - "All (OSS + Alpine + Pro)"
+          - "All (OSS + Alpine + Pro + Secure)"
           - "OSS Only (Standard + Alpine)"
           - "Pro Only"
+          - "Secure Only"
           - "Standard OSS Only"
           - "Alpine OSS Only"
-        default: "All (OSS + Alpine + Pro)"
+        default: "All (OSS + Alpine + Pro + Secure)"
 
 jobs:
   set-matrix:
@@ -38,10 +39,11 @@ jobs:
           matrix_items=()
 
           case "${{ inputs.buildTargets }}" in
-            "All (OSS + Alpine + Pro)")
+            "All (OSS + Alpine + Pro + Secure)")
               matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss"}')
               matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "oss"}')
               matrix_items+=('{"dockerfile": "DockerfilePro", "image_name": "liquibase-pro-qa", "suffix": "-pro", "build_type": "pro"}')
+              matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-qa", "suffix": "-secure", "build_type": "secure"}')
               ;;
             "OSS Only (Standard + Alpine)")
               matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss"}')
@@ -49,6 +51,9 @@ jobs:
               ;;
             "Pro Only")
               matrix_items+=('{"dockerfile": "DockerfilePro", "image_name": "liquibase-pro-qa", "suffix": "-pro", "build_type": "pro"}')
+              ;;
+            "Secure Only")
+              matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-qa", "suffix": "-secure", "build_type": "secure"}')
               ;;
             "Standard OSS Only")
               matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss"}')
@@ -87,15 +92,15 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
-      - name: Configure AWS credentials for Pro builds
-        if: ${{ matrix.build_type == 'pro' }}
+      - name: Configure AWS credentials for Pro/Secure builds
+        if: ${{ matrix.build_type == 'pro' || matrix.build_type == 'secure' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_PROD_GITHUB_OIDC_ROLE_ARN_LIQUIBASE_PRO }}
           aws-region: us-east-1
 
-      - name: Get GitHub App token for Pro workflow trigger
-        if: ${{ matrix.build_type == 'pro' }}
+      - name: Get GitHub App token for Pro/Secure workflow trigger
+        if: ${{ matrix.build_type == 'pro' || matrix.build_type == 'secure' }}
         id: get-token
         uses: actions/create-github-app-token@v2
         with:
@@ -139,10 +144,10 @@ jobs:
       - name: Download liquibase build artifact (OSS) or from S3 (Pro)
         id: download-artifact
         run: |
-          if [[ "${{ matrix.build_type }}" == "pro" ]]; then
+          if [[ "${{ matrix.build_type }}" == "pro" || "${{ matrix.build_type }}" == "secure" ]]; then
             echo "Downloading Liquibase Pro build from S3..."
 
-            # Download Pro build from S3
+            # Download Pro build from S3 (same binary for both Pro and Secure)
             LIQUIBASE_PRO_ZIP="liquibase-pro-${{ inputs.liquibaseBranch }}.zip"
             S3_URL="s3://repo.liquibase.com/releases/pro/${{ inputs.liquibaseBranch }}/$LIQUIBASE_PRO_ZIP"
 
@@ -250,7 +255,7 @@ jobs:
           fi
 
       - name: Trigger Pro Release Workflow
-        if: ${{ matrix.build_type == 'pro' && steps.download-artifact.outputs.trigger_pro_workflow == 'true' && steps.download-artifact.outputs.use_fallback != 'true' }}
+        if: ${{ (matrix.build_type == 'pro' || matrix.build_type == 'secure') && steps.download-artifact.outputs.trigger_pro_workflow == 'true' && steps.download-artifact.outputs.use_fallback != 'true' }}
         id: trigger-pro-release
         continue-on-error: true
         uses: the-actions-org/workflow-dispatch@v4
@@ -265,7 +270,7 @@ jobs:
           wait-for-completion-interval: 10m
 
       - name: Download Pro build from S3 after workflow completion
-        if: ${{ matrix.build_type == 'pro' && steps.download-artifact.outputs.trigger_pro_workflow == 'true' && steps.download-artifact.outputs.use_fallback != 'true' }}
+        if: ${{ (matrix.build_type == 'pro' || matrix.build_type == 'secure') && steps.download-artifact.outputs.trigger_pro_workflow == 'true' && steps.download-artifact.outputs.use_fallback != 'true' }}
         id: download-after-trigger
         run: |
           LIQUIBASE_PRO_ZIP="liquibase-pro-${{ inputs.liquibaseBranch }}.zip"
@@ -294,15 +299,15 @@ jobs:
           echo "use_fallback=false" >> $GITHUB_OUTPUT
 
       - name: Validate and prepare liquibase build
-        if: ${{ (matrix.build_type == 'oss' && (steps.download-artifact.outputs.build_ready == 'true' || steps.download-artifact.outputs.use_fallback == 'true')) || matrix.build_type == 'pro' }}
+        if: ${{ (matrix.build_type == 'oss' && (steps.download-artifact.outputs.build_ready == 'true' || steps.download-artifact.outputs.use_fallback == 'true')) || matrix.build_type == 'pro' || matrix.build_type == 'secure' }}
         id: validate-build
         run: |
           # Determine build mode
           USE_FALLBACK="false"
           if [[ "${{ matrix.build_type }}" == "oss" && "${{ steps.download-artifact.outputs.use_fallback }}" == "true" ]]; then
             USE_FALLBACK="true"
-          elif [[ "${{ matrix.build_type }}" == "pro" ]]; then
-            # Check for Pro fallback conditions
+          elif [[ "${{ matrix.build_type }}" == "pro" || "${{ matrix.build_type }}" == "secure" ]]; then
+            # Check for Pro/Secure fallback conditions
             if [[ "${{ steps.download-artifact.outputs.use_fallback }}" == "true" ]] || [[ "${{ steps.download-after-trigger.outputs.use_fallback }}" == "true" ]]; then
               USE_FALLBACK="true"
             # Check if Pro workflow was triggered but failed
@@ -349,7 +354,7 @@ jobs:
           cp "${{ matrix.dockerfile }}" "${{ matrix.dockerfile }}.backup"
 
           # Set version ARG based on dockerfile type
-          if [[ "${{ matrix.dockerfile }}" == "DockerfilePro" ]]; then
+          if [[ "${{ matrix.dockerfile }}" == "DockerfilePro" || "${{ matrix.dockerfile }}" == "DockerfileSecure" ]]; then
             VERSION_ARG="LIQUIBASE_PRO_VERSION"
           else
             VERSION_ARG="LIQUIBASE_VERSION"
@@ -398,6 +403,18 @@ jobs:
 
           # Handle Pro Dockerfile wget block
           dockerfile == "DockerfilePro" && /^RUN wget.*repo\.liquibase\.com.*tar\.gz/ {
+            print "# Copy the extracted liquibase build from the build context"
+            print "COPY liquibase-build/ ./"
+            print ""
+            print "RUN ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
+            print "    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \\"
+            print "    liquibase --version"
+            in_wget_block = 1
+            next
+          }
+
+          # Handle Secure Dockerfile wget block
+          dockerfile == "DockerfileSecure" && /^RUN wget.*repo\.liquibase\.com.*tar\.gz/ {
             print "# Copy the extracted liquibase build from the build context"
             print "COPY liquibase-build/ ./"
             print ""

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,7 +8,7 @@ permissions:
   
 on:
   repository_dispatch:
-    types: [liquibase-release, liquibase-pro-release]
+    types: [liquibase-release, liquibase-pro-release, liquibase-secure-release]
   workflow_dispatch:
     inputs:
       releaseType:
@@ -19,6 +19,7 @@ on:
         options:
           - liquibase-release
           - liquibase-pro-release
+          - liquibase-secure-release
       liquibaseVersion:
         description: "Liquibase Version"
         required: true
@@ -184,6 +185,26 @@ jobs:
               git commit -m "${COMMIT_MSG}"
               echo "changes_made=true" >> $GITHUB_OUTPUT
             fi
+          elif [[ "${{ steps.collect-data.outputs.releaseType }}" == "liquibase-secure-release" ]]; then
+            file_list=("DockerfileSecure")
+            LIQUIBASE_PRO_SHA=$(curl -LsS https://repo.liquibase.com/releases/pro/${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-pro-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }')
+            LPM_SHA=$(curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip | sha256sum | awk '{ print $1 }')
+            LPM_SHA_ARM=$(curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux-arm64.zip | sha256sum | awk '{ print $1 }')
+            for file in "${file_list[@]}"; do
+              sed -i 's/^ARG LIQUIBASE_PRO_VERSION=.*/ARG LIQUIBASE_PRO_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' "${{ github.workspace }}/${file}"
+              sed -i 's/^ARG LB_PRO_SHA256=.*/ARG LB_PRO_SHA256='"$LIQUIBASE_PRO_SHA"'/' "${{ github.workspace }}/${file}"
+              sed -i 's/^ARG LPM_SHA256=.*/ARG LPM_SHA256='"$LPM_SHA"'/' "${{ github.workspace }}/${file}"
+              sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
+              git add "${file}"
+            done
+            if git diff-index --cached --quiet HEAD --; then
+              echo "Nothing new to commit"
+              echo "changes_made=false" >> $GITHUB_OUTPUT
+            else
+              COMMIT_MSG="Liquibase Secure Version Bumped to ${{ steps.collect-data.outputs.liquibaseVersion }}"
+              git commit -m "${COMMIT_MSG}"
+              echo "changes_made=true" >> $GITHUB_OUTPUT
+            fi
           else
             file_list=("Dockerfile" "Dockerfile.alpine")
             LIQUIBASE_SHA=$(curl -LsS https://github.com/liquibase/liquibase/releases/download/v${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }')
@@ -218,6 +239,10 @@ jobs:
             TAG_NAME="v${VERSION}-PRO"
             COMMIT_MSG="Liquibase PRO Version Bumped to ${VERSION}"
             TAG_MSG="Version Bumped to ${VERSION} PRO"
+          elif [[ "${RELEASE_TYPE}" == "liquibase-secure-release" ]]; then
+            TAG_NAME="v${VERSION}-SECURE"
+            COMMIT_MSG="Liquibase Secure Version Bumped to ${VERSION}"
+            TAG_MSG="Version Bumped to ${VERSION} Secure"
           else
             TAG_NAME="v${EXTENSION_VERSION}"
             COMMIT_MSG="Liquibase Version Bumped to ${EXTENSION_VERSION}"
@@ -262,6 +287,11 @@ jobs:
             suffix: ""
             latest_tag: "latest"
             type: liquibase-pro-release
+          - dockerfile: DockerfileSecure
+            name: liquibase/liquibase-secure
+            suffix: ""
+            latest_tag: "latest"
+            type: liquibase-secure-release
     steps:
       - uses: actions/checkout@v4
         with:
@@ -294,14 +324,14 @@ jobs:
           distribution: "adopt"
 
       - name: Release Notes
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && ((needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release') || (needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && matrix.type == 'liquibase-pro-release')) }}
+        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && ((needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release') || (needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && matrix.type == 'liquibase-pro-release') || (needs.update-dockerfiles.outputs.releaseType == 'liquibase-secure-release' && matrix.type == 'liquibase-secure-release')) }}
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && format('v{0} PRO', needs.update-dockerfiles.outputs.extensionVersion) || format('v{0}', needs.update-dockerfiles.outputs.extensionVersion) }}
+          name: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && format('v{0} PRO', needs.update-dockerfiles.outputs.extensionVersion) || needs.update-dockerfiles.outputs.releaseType == 'liquibase-secure-release' && format('v{0} SECURE', needs.update-dockerfiles.outputs.extensionVersion) || format('v{0}', needs.update-dockerfiles.outputs.extensionVersion) }}
           tag_name: v${{ needs.update-dockerfiles.outputs.extensionVersion }}
           draft: true
           body: |
-            ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && format('Support for Liquibase PRO {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) || format('Support for Liquibase {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) }}
+            ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && format('Support for Liquibase PRO {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) || needs.update-dockerfiles.outputs.releaseType == 'liquibase-secure-release' && format('Support for Liquibase Secure {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) || format('Support for Liquibase {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -320,6 +350,10 @@ jobs:
             echo "DOCKERHUB_REPO=${{ matrix.name }}" >> $GITHUB_OUTPUT
             echo "ECR_REPO=public.ecr.aws/liquibase/liquibase-pro" >> $GITHUB_OUTPUT
             echo "GHCR_REPO=ghcr.io/liquibase/liquibase-pro" >> $GITHUB_OUTPUT
+          elif [[ "${{ matrix.type }}" == "liquibase-secure-release" ]]; then
+            echo "DOCKERHUB_REPO=${{ matrix.name }}" >> $GITHUB_OUTPUT
+            echo "ECR_REPO=public.ecr.aws/liquibase/liquibase-secure" >> $GITHUB_OUTPUT
+            echo "GHCR_REPO=ghcr.io/liquibase/liquibase-secure" >> $GITHUB_OUTPUT
           fi
 
       # Use separate login steps for each registry
@@ -437,7 +471,7 @@ jobs:
           # Labels applied to each architecture-specific image
           labels: |
             org.opencontainers.image.source=https://github.com/liquibase/docker
-            org.opencontainers.image.description=${{ matrix.type == 'liquibase-pro-release' && 'Liquibase PRO Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
+            org.opencontainers.image.description=${{ matrix.type == 'liquibase-pro-release' && 'Liquibase PRO Container Image' || matrix.type == 'liquibase-secure-release' && 'Liquibase Secure Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
             org.opencontainers.image.licenses=Apache-2.0
             org.opencontainers.image.vendor=Liquibase
             org.opencontainers.image.version=${{ needs.update-dockerfiles.outputs.extensionVersion }}
@@ -445,7 +479,7 @@ jobs:
           # Annotations applied to the manifest list (important for multi-arch images)
           annotations: |
             org.opencontainers.image.source=https://github.com/liquibase/docker
-            org.opencontainers.image.description=${{ matrix.type == 'liquibase-pro-release' && 'Liquibase PRO Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
+            org.opencontainers.image.description=${{ matrix.type == 'liquibase-pro-release' && 'Liquibase PRO Container Image' || matrix.type == 'liquibase-secure-release' && 'Liquibase Secure Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
             org.opencontainers.image.licenses=Apache-2.0
             org.opencontainers.image.vendor=Liquibase
             org.opencontainers.image.version=${{ needs.update-dockerfiles.outputs.extensionVersion }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ This is the official Liquibase Docker image repository that builds and publishes
 
 - **Dockerfile**: Standard Liquibase OSS image
 - **DockerfilePro**: Liquibase Pro image with enterprise features
+- **DockerfileSecure**: Liquibase Secure image (enterprise features)
 - **Dockerfile.alpine**: Alpine Linux variant (lightweight)
 - **Examples**: Database-specific extensions (AWS CLI, SQL Server, PostgreSQL, Oracle)
 - **Docker Compose**: Complete example with PostgreSQL
@@ -15,7 +16,7 @@ This is the official Liquibase Docker image repository that builds and publishes
 ## Image Publishing
 
 Images are published to multiple registries:
-- Docker Hub: `liquibase/liquibase` (OSS) and `liquibase/liquibase-pro` (Pro)
+- Docker Hub: `liquibase/liquibase` (OSS), `liquibase/liquibase-pro` (Pro), and `liquibase/liquibase-secure` (Secure)
 - GitHub Container Registry: `ghcr.io/liquibase/liquibase*`
 - Amazon ECR Public: `public.ecr.aws/liquibase/liquibase*`
 
@@ -30,6 +31,9 @@ docker build -f Dockerfile -t liquibase/liquibase:latest .
 # Build Pro image
 docker build -f DockerfilePro -t liquibase/liquibase-pro:latest .
 
+# Build Secure image
+docker build -f DockerfileSecure -t liquibase/liquibase-secure:latest .
+
 # Build Alpine variant
 docker build -f Dockerfile.alpine -t liquibase/liquibase:latest-alpine .
 ```
@@ -42,6 +46,9 @@ docker run --rm liquibase/liquibase:latest --version
 
 # Test Pro image (requires license)
 docker run --rm -e LIQUIBASE_LICENSE_KEY="your-key" liquibase/liquibase-pro:latest --version
+
+# Test Secure image (requires license)
+docker run --rm -e LIQUIBASE_LICENSE_KEY="your-key" liquibase/liquibase-secure:latest --version
 
 # Run with example changelog
 docker run --rm -v $(pwd)/examples/docker-compose/changelog:/liquibase/changelog liquibase/liquibase:latest --changelog-file=db.changelog-master.xml validate
@@ -56,6 +63,9 @@ docker-compose up
 
 # Use local build for testing
 docker-compose -f docker-compose.local.yml up --build
+
+# Run with Liquibase Secure
+docker-compose -f docker-compose.secure.yml up
 ```
 
 ## Architecture
@@ -67,12 +77,12 @@ docker-compose -f docker-compose.local.yml up --build
 - **Entrypoint**: `docker-entrypoint.sh` with automatic MySQL driver installation
 
 ### Key Components
-- **Liquibase**: Database migration tool (OSS: GitHub releases, Pro: repo.liquibase.com)
+- **Liquibase**: Database migration tool (OSS: GitHub releases, Pro/Secure: repo.liquibase.com)
 - **LPM**: Liquibase Package Manager for extensions
 - **Default Config**: `liquibase.docker.properties` sets headless mode
 
 ### Version Management
-- Liquibase versions are controlled via `LIQUIBASE_VERSION` (OSS) and `LIQUIBASE_PRO_VERSION` (Pro) ARGs
+- Liquibase versions are controlled via `LIQUIBASE_VERSION` (OSS) and `LIQUIBASE_PRO_VERSION` (Pro/Secure) ARGs
 - SHA256 checksums are validated for security
 - LPM version is specified via `LPM_VERSION` ARG
 
@@ -84,8 +94,8 @@ docker-compose -f docker-compose.local.yml up --build
 - `LIQUIBASE_COMMAND_PASSWORD`: Database password
 - `LIQUIBASE_COMMAND_CHANGELOG_FILE`: Path to changelog file
 
-### Pro Features (DockerfilePro only)
-- `LIQUIBASE_LICENSE_KEY`: Required for Pro features
+### Pro/Secure Features (DockerfilePro and DockerfileSecure only)
+- `LIQUIBASE_LICENSE_KEY`: Required for Pro/Secure features
 - `LIQUIBASE_PRO_POLICY_CHECKS_ENABLED`: Enable policy checks
 - `LIQUIBASE_PRO_QUALITY_CHECKS_ENABLED`: Enable quality checks
 
@@ -100,6 +110,12 @@ docker-compose -f docker-compose.local.yml up --build
 ```dockerfile
 FROM liquibase/liquibase:latest
 RUN lpm add mysql --global
+```
+
+### Using Liquibase Secure
+```dockerfile
+FROM liquibase/liquibase-secure:latest
+ENV LIQUIBASE_LICENSE_KEY=your-license-key
 ```
 
 ### Adding Tools (e.g., AWS CLI)

--- a/DockerfileSecure
+++ b/DockerfileSecure
@@ -1,0 +1,73 @@
+# Builder Stage
+FROM eclipse-temurin:21-jre-jammy
+
+# Create liquibase user
+RUN groupadd --gid 1001 liquibase && \
+    useradd --uid 1001 --gid liquibase --create-home --home-dir /liquibase liquibase && \
+    chown liquibase /liquibase
+
+# Download and install Liquibase
+WORKDIR /liquibase
+
+ARG LIQUIBASE_PRO_VERSION=4.33.0
+ARG LB_PRO_SHA256=f36d71194927a1fea1325f0ce17e1995b169a2a6d4de3166797230cb01791b0d
+
+# Add metadata labels
+LABEL org.opencontainers.image.description="Liquibase Secure Container Image"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="Liquibase"
+LABEL org.opencontainers.image.version="${LIQUIBASE_PRO_VERSION}"
+LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"
+
+# Download and install Liquibase
+WORKDIR /liquibase
+
+RUN wget -q -O liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz "https://repo.liquibase.com/releases/pro/${LIQUIBASE_PRO_VERSION}/liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz" && \
+    echo "$LB_PRO_SHA256 *liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz" | sha256sum -c - && \
+    tar -xzf liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz && \
+    rm liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz && \
+    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \
+    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
+    liquibase --version
+    
+ARG LPM_VERSION=0.2.11
+ARG LPM_SHA256=d07d1373446d2a9f11010649d705eba2ebefc23aedffec58d4d0a117c9a195b7
+ARG LPM_SHA256_ARM=77c8cf8369ad07ed536c3b4c352e40815f32f89b111cafabf8e3cfc102d912f8
+
+# Download and Install lpm
+RUN apt-get update && \
+    apt-get -yqq install unzip --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /liquibase/bin && \
+    arch="$(dpkg --print-architecture)" && \
+    if [ "$arch" = "amd64" ]; then \
+        DOWNLOAD_ARCH=""; \
+        DOWNLOAD_SHA256="$LPM_SHA256"; \
+    elif [ "$arch" = "arm64" ]; then \
+        DOWNLOAD_ARCH="-arm64"; \
+        DOWNLOAD_SHA256="$LPM_SHA256_ARM"; \
+    else \
+        echo >&2 "error: unsupported architecture '$arch'"; \
+        exit 1; \
+    fi && \
+    wget -q -O /tmp/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip "https://github.com/liquibase/liquibase-package-manager/releases/download/v${LPM_VERSION}/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" && \
+    echo "$DOWNLOAD_SHA256 */tmp/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" | sha256sum -c - && \
+    unzip /tmp/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip -d /liquibase/bin/ && \
+    rm /tmp/lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip && \
+    apt-get purge -y --auto-remove unzip && \
+    ln -s /liquibase/bin/lpm /usr/local/bin/lpm && \
+    lpm --version
+    
+# Set LIQUIBASE_HOME environment variable
+ENV LIQUIBASE_HOME=/liquibase
+# Marker which indicates this is a Liquibase docker container
+ENV DOCKER_LIQUIBASE=true
+
+COPY docker-entrypoint.sh ./
+COPY liquibase.docker.properties ./
+
+# Set user and group
+USER liquibase:liquibase
+
+ENTRYPOINT ["/liquibase/docker-entrypoint.sh"]
+CMD ["--help"]

--- a/examples/docker-compose/docker-compose.secure.yml
+++ b/examples/docker-compose/docker-compose.secure.yml
@@ -1,0 +1,38 @@
+services:
+  # PostgreSQL database
+  postgres:
+    image: postgres:15-alpine
+    container_name: liquibase_postgres
+    environment:
+      POSTGRES_DB: liquibase_demo
+      POSTGRES_USER: liquibase
+      POSTGRES_PASSWORD: liquibase_password
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U liquibase -d liquibase_demo"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Liquibase Secure service
+  liquibase:
+    image: liquibase/liquibase-secure:latest
+    container_name: liquibase_secure_runner
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ./changelog:/liquibase/changelog
+      - ./liquibase.properties:/liquibase/liquibase.properties
+    environment:
+      LIQUIBASE_COMMAND_URL: jdbc:postgresql://postgres:5432/liquibase_demo
+      LIQUIBASE_COMMAND_USERNAME: liquibase
+      LIQUIBASE_COMMAND_PASSWORD: liquibase_password
+      LIQUIBASE_LICENSE_KEY: ${LIQUIBASE_LICENSE_KEY}  # Set in your environment
+    command: ["--defaults-file=/liquibase/liquibase.properties", "update"]
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
This pull request adds support for a new "Liquibase Secure" Docker image variant across the repository. The changes update documentation, CI workflows, and release automation to include the Secure image alongside the existing OSS and Pro images. The most important updates are grouped below by theme.

**Workflow and Release Automation Enhancements:**

* Updated `.github/workflows/build-qa-docker.yml` to support building and releasing the Secure image, including new build target options, matrix entries, AWS credential handling, artifact download logic, and Dockerfile processing for Secure builds. [[1]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL21-R27) [[2]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL41-R46) [[3]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dR55-R57) [[4]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL90-R103) [[5]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL142-R150) [[6]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL253-R258) [[7]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL268-R273) [[8]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL297-R310) [[9]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL352-R357) [[10]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dR416-R427)
* Enhanced `.github/workflows/create-release.yml` to handle Secure releases, including new event types, releaseType options, Dockerfile updates, tagging, matrix entries, release notes, registry targets, and image labels/annotations for Secure builds. [[1]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L11-R11) [[2]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R22) [[3]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R188-R207) [[4]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R242-R245) [[5]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R290-R294) [[6]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L297-R334) [[7]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R353-R356) [[8]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L440-R482)

**Documentation Updates:**

* Updated `CLAUDE.md` to describe the new `DockerfileSecure`, document Secure image publishing to Docker Hub, and add Secure build/test instructions for both Docker and Docker Compose. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R11-R19) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R34-R36) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R50-R52) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R66-R68)