### PR TITLE
fix: Update S3 URL for downloading Liquibase Secure builds

### DIFF
--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -144,7 +144,7 @@ jobs:
 
             # Download Liquibase-Secure build from S3
             LIQUIBASE_SECURE_ZIP="liquibase-pro-${{ inputs.liquibaseBranch }}.zip"
-            S3_URL="s3://repo.liquibase.com/releases/pro/${{ inputs.liquibaseBranch }}/$LIQUIBASE_SECURE_ZIP"
+            S3_URL="s3://repo.liquibase.com/releases/secure/${{ inputs.liquibaseBranch }}/$LIQUIBASE_SECURE_ZIP"
 
             echo "Downloading from S3: $S3_URL"
 
@@ -269,7 +269,7 @@ jobs:
         id: download-after-trigger
         run: |
           LIQUIBASE_SECURE_ZIP="liquibase-pro-${{ inputs.liquibaseBranch }}.zip"
-          S3_URL="s3://repo.liquibase.com/releases/pro/${{ inputs.liquibaseBranch }}/$LIQUIBASE_SECURE_ZIP"
+          S3_URL="s3://repo.liquibase.com/releases/secure/${{ inputs.liquibaseBranch }}/$LIQUIBASE_SECURE_ZIP"
 
           echo "⬇️ Downloading Liquibase Secure build from S3 after workflow completion..."
           


### PR DESCRIPTION
This pull request updates the S3 bucket path used to download the Liquibase Secure build in the `.github/workflows/build-qa-docker.yml` workflow. The path is changed from the `pro` directory to the `secure` directory to ensure the correct build is fetched.

**Workflow configuration update:**

* Changed the S3 URL path from `releases/pro` to `releases/secure` in both the initial and post-trigger download steps in `.github/workflows/build-qa-docker.yml`. [[1]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL147-R147) [[2]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL272-R272)