### PR TITLE
fix/DAT-20655: Update Liquibase installation to use secure version

### DIFF
--- a/DockerfileSecure
+++ b/DockerfileSecure
@@ -9,8 +9,8 @@ RUN groupadd --gid 1001 liquibase && \
 # Download and install Liquibase
 WORKDIR /liquibase
 
-ARG LIQUIBASE_SECURE_VERSION=5-secure-release-test
-ARG LB_SECURE_SHA256=d40fca9a209f2ad224e6c8d4d5cd02f2119c85684514606356c2b8facec337f7
+ARG LIQUIBASE_SECURE_VERSION=4.33.0
+ARG LB_SECURE_SHA256=f36d71194927a1fea1325f0ce17e1995b169a2a6d4de3166797230cb01791b0d
 
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Secure Container Image"

--- a/DockerfileSecure
+++ b/DockerfileSecure
@@ -9,8 +9,8 @@ RUN groupadd --gid 1001 liquibase && \
 # Download and install Liquibase
 WORKDIR /liquibase
 
-ARG LIQUIBASE_SECURE_VERSION=4.33.0
-ARG LB_SECURE_SHA256=f36d71194927a1fea1325f0ce17e1995b169a2a6d4de3166797230cb01791b0d
+ARG LIQUIBASE_SECURE_VERSION=5-secure-release-test
+ARG LB_SECURE_SHA256=c3a56fc305cd3de8fafd720a2bef7e18d66b7a7a516b38e8c185d096e7ca37f6
 
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Secure Container Image"

--- a/DockerfileSecure
+++ b/DockerfileSecure
@@ -22,10 +22,10 @@ LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"
 # Download and install Liquibase
 WORKDIR /liquibase
 
-RUN wget -q -O liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz "https://repo.liquibase.com/releases/pro/${LIQUIBASE_SECURE_VERSION}/liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz" && \
-    echo "$LB_SECURE_SHA256 *liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz" | sha256sum -c - && \
-    tar -xzf liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz && \
-    rm liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz && \
+RUN wget -q -O liquibase-secure-${LIQUIBASE_SECURE_VERSION}.tar.gz "https://repo.liquibase.com/releases/secure/${LIQUIBASE_SECURE_VERSION}/liquibase-secure-${LIQUIBASE_SECURE_VERSION}.tar.gz" && \
+    echo "$LB_SECURE_SHA256 *liquibase-secure-${LIQUIBASE_SECURE_VERSION}.tar.gz" | sha256sum -c - && \
+    tar -xzf liquibase-secure-${LIQUIBASE_SECURE_VERSION}.tar.gz && \
+    rm liquibase-secure-${LIQUIBASE_SECURE_VERSION}.tar.gz && \
     ln -s /liquibase/liquibase /usr/local/bin/liquibase && \
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version

--- a/DockerfileSecure
+++ b/DockerfileSecure
@@ -10,7 +10,7 @@ RUN groupadd --gid 1001 liquibase && \
 WORKDIR /liquibase
 
 ARG LIQUIBASE_SECURE_VERSION=5-secure-release-test
-ARG LB_SECURE_SHA256=c3a56fc305cd3de8fafd720a2bef7e18d66b7a7a516b38e8c185d096e7ca37f6
+ARG LB_SECURE_SHA256=d40fca9a209f2ad224e6c8d4d5cd02f2119c85684514606356c2b8facec337f7
 
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Secure Container Image"


### PR DESCRIPTION
This pull request updates the Liquibase installation process in the `DockerfileSecure` to use the secure edition instead of the pro edition. The download URL, archive name, and checksum verification have all been switched to reference the secure release.

Liquibase installation process updates:

* Changed the Liquibase download URL from the pro edition to the secure edition, updating the path and filename accordingly.
* Updated the checksum verification and extraction steps to use the secure edition archive name.

**Testing step**

https://datical.atlassian.net/browse/DAT-20655?focusedCommentId=169184