### PR TITLE
DAT-20836 Docker: LPM permission denied error when running as liquibase user in OSS 5.0

### DIFF
--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -373,6 +373,18 @@ jobs:
             skip_line = 0
           }
 
+          # Function to handle wget block replacement
+          function replace_wget_block() {
+            print "# Copy the extracted liquibase build from the build context"
+            print "COPY liquibase-build/ ./"
+            print ""
+            print "RUN chown -R liquibase:liquibase /liquibase && \\"
+            print "    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
+            print "    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \\"
+            print "    liquibase --version"
+            in_wget_block = 1
+          }
+
           # Skip SHA256 ARG lines
           /^ARG LB_SHA256=/ || /^ARG LB_PRO_SHA256=/ { next }
 
@@ -380,43 +392,11 @@ jobs:
           /^ARG LIQUIBASE_VERSION=/ { print "ARG LIQUIBASE_VERSION=" branch; next }
           /^ARG LIQUIBASE_PRO_VERSION=/ { print "ARG LIQUIBASE_PRO_VERSION=" branch; next }
 
-          # Handle standard Dockerfile wget block
-          dockerfile == "Dockerfile" && /^RUN wget.*package\.liquibase\.com/ {
-            print "# Copy the extracted liquibase build from the build context"
-            print "COPY liquibase-build/ ./"
-            print ""
-            print "RUN chown -R liquibase:liquibase /liquibase && \\"
-            print "    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
-            print "    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \\"
-            print "    liquibase --version"
-            in_wget_block = 1
-            # Skip the rest of this line and continue skipping until we find the end
-            next
-          }
-
-          # Handle alpine Dockerfile wget block
-          dockerfile == "Dockerfile.alpine" && /^RUN set -x/ {
-            print "# Copy the extracted liquibase build from the build context"
-            print "COPY liquibase-build/ ./"
-            print ""
-            print "RUN chown -R liquibase:liquibase /liquibase && \\"
-            print "    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
-            print "    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \\"
-            print "    liquibase --version"
-            in_wget_block = 1
-            next
-          }
-
-          # Handle Pro Dockerfile wget block
-          dockerfile == "DockerfilePro" && /^RUN wget.*package\.liquibase\.com/ {
-            print "# Copy the extracted liquibase build from the build context"
-            print "COPY liquibase-build/ ./"
-            print ""
-            print "RUN chown -R liquibase:liquibase /liquibase && \\"
-            print "    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
-            print "    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \\"
-            print "    liquibase --version"
-            in_wget_block = 1
+          # Handle different Dockerfile wget blocks
+          (dockerfile == "Dockerfile" && /^RUN wget.*package\.liquibase\.com/) ||
+          (dockerfile == "Dockerfile.alpine" && /^RUN set -x/) ||
+          (dockerfile == "DockerfilePro" && /^RUN wget.*package\.liquibase\.com/) {
+            replace_wget_block()
             next
           }
 

--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -385,7 +385,8 @@ jobs:
             print "# Copy the extracted liquibase build from the build context"
             print "COPY liquibase-build/ ./"
             print ""
-            print "RUN ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
+            print "RUN chown -R liquibase:liquibase /liquibase && \\"
+            print "    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
             print "    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \\"
             print "    liquibase --version"
             in_wget_block = 1
@@ -398,7 +399,8 @@ jobs:
             print "# Copy the extracted liquibase build from the build context"
             print "COPY liquibase-build/ ./"
             print ""
-            print "RUN ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
+            print "RUN chown -R liquibase:liquibase /liquibase && \\"
+            print "    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
             print "    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \\"
             print "    liquibase --version"
             in_wget_block = 1
@@ -410,7 +412,8 @@ jobs:
             print "# Copy the extracted liquibase build from the build context"
             print "COPY liquibase-build/ ./"
             print ""
-            print "RUN ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
+            print "RUN chown -R liquibase:liquibase /liquibase && \\"
+            print "    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
             print "    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \\"
             print "    liquibase --version"
             in_wget_block = 1


### PR DESCRIPTION
This pull request updates the Docker build process in the `.github/workflows/build-qa-docker.yml` file to improve file ownership handling for the Liquibase build. The main change ensures that the `/liquibase` directory and its contents have the correct ownership before creating symlinks and running Liquibase commands.

Improvements to Docker build process:

* Added a `chown -R liquibase:liquibase /liquibase` command before creating symlinks and running Liquibase to ensure proper ownership of files and directories during the build. [[1]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL388-R389) [[2]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL401-R403) [[3]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL413-R416)