### PR TITLE
DAT-20655 v2 Rebranding: Create new Liquibase Secure Docker Image and location on Docker Hub

### DIFF
--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -107,7 +107,7 @@ jobs:
           permission-actions: write
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install jq
         run: |
@@ -272,7 +272,7 @@ jobs:
           S3_URL="s3://repo.liquibase.com/releases/pro/${{ inputs.liquibaseBranch }}/$LIQUIBASE_SECURE_ZIP"
 
           echo "⬇️ Downloading Liquibase Secure build from S3 after workflow completion..."
-          
+
           if ! aws s3 cp "$S3_URL" "$LIQUIBASE_SECURE_ZIP"; then
             echo "❌ Failed to download Liquibase Secure build even after workflow completion"
             echo "Will use fallback build from branch source instead"
@@ -315,7 +315,7 @@ jobs:
               USE_FALLBACK="true"
             fi
           fi
-          
+
           if [[ "$USE_FALLBACK" == "true" ]]; then
             echo "Using fallback mode - will build from standard Dockerfile using branch source"
             echo "use_fallback_build=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -154,8 +154,8 @@ jobs:
               if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-RC([0-9]+)$ ]]; then
                 BASE_VERSION="${BASH_REMATCH[1]}"
                 RC_NUMBER="${BASH_REMATCH[2]}"
-                LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.zip"
-                S3_URL="s3://repo.liquibase.com/release-candidates/${BASE_VERSION}/RC${RC_NUMBER}/${LIQUIBASE_SECURE_ZIP}"
+                LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.tar.gz"
+                S3_URL="s3://repo.liquibase.com/releases/rc/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
                 echo "Using RC S3 path: $S3_URL"
               else
                 # Regular production version
@@ -201,10 +201,15 @@ jobs:
               echo "build_ready=true" >> $GITHUB_OUTPUT
               echo "use_fallback=false" >> $GITHUB_OUTPUT
 
-              # Extract the liquibase Secure zip
+              # Extract the liquibase Secure archive
               mkdir -p liquibase-build
-              unzip -q "$LIQUIBASE_SECURE_ZIP" -d liquibase-build/
-              echo "Liquibase Secure build extracted to liquibase-build/"
+              if [[ "$LIQUIBASE_SECURE_ZIP" == *.tar.gz ]]; then
+                tar -xzf "$LIQUIBASE_SECURE_ZIP" -C liquibase-build/
+                echo "Liquibase Secure build extracted from tar.gz to liquibase-build/"
+              else
+                unzip -q "$LIQUIBASE_SECURE_ZIP" -d liquibase-build/
+                echo "Liquibase Secure build extracted from zip to liquibase-build/"
+              fi
             fi
 
           else
@@ -308,8 +313,8 @@ jobs:
             if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-RC([0-9]+)$ ]]; then
               BASE_VERSION="${BASH_REMATCH[1]}"
               RC_NUMBER="${BASH_REMATCH[2]}"
-              LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.zip"
-              S3_URL="s3://repo.liquibase.com/release-candidates/${BASE_VERSION}/RC${RC_NUMBER}/${LIQUIBASE_SECURE_ZIP}"
+              LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.tar.gz"
+              S3_URL="s3://repo.liquibase.com/releases/rc/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
             else
               LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.zip"
               S3_URL="s3://repo.liquibase.com/releases/secure/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
@@ -331,11 +336,15 @@ jobs:
 
           echo "✅ Successfully downloaded Liquibase Secure build after workflow completion"
 
-          # Extract the liquibase Secure zip
+          # Extract the liquibase Secure archive
           mkdir -p liquibase-build
-          unzip -q "$LIQUIBASE_SECURE_ZIP" -d liquibase-build/
-
-          echo "Liquibase Secure build extracted to liquibase-build/"
+          if [[ "$LIQUIBASE_SECURE_ZIP" == *.tar.gz ]]; then
+            tar -xzf "$LIQUIBASE_SECURE_ZIP" -C liquibase-build/
+            echo "Liquibase Secure build extracted from tar.gz to liquibase-build/"
+          else
+            unzip -q "$LIQUIBASE_SECURE_ZIP" -d liquibase-build/
+            echo "Liquibase Secure build extracted from zip to liquibase-build/"
+          fi
           echo "Contents of liquibase-build:"
           ls -la liquibase-build/
           echo "build_ready=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -41,24 +41,39 @@ jobs:
         run: |
           matrix_items=()
 
+          # Determine if this is an RC build (secure-version contains "-RC")
+          IS_RC_BUILD="false"
+          if [[ -n "${{ inputs.secure-version }}" && "${{ inputs.secure-version }}" =~ -RC[0-9]+$ ]]; then
+            IS_RC_BUILD="true"
+            echo "Detected RC build with version: ${{ inputs.secure-version }}"
+          fi
+
           case "${{ inputs.buildTargets }}" in
             "All (OSS + Alpine + Secure)")
-              matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss"}')
-              matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "oss"}')
-              matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-qa", "suffix": "-secure", "build_type": "secure"}')
+              matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss", "is_rc": false}')
+              matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "oss", "is_rc": false}')
+              if [[ "$IS_RC_BUILD" == "true" ]]; then
+                matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-rc", "suffix": "-secure", "build_type": "secure", "is_rc": true}')
+              else
+                matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-qa", "suffix": "-secure", "build_type": "secure", "is_rc": false}')
+              fi
               ;;
             "OSS Only (Standard + Alpine)")
-              matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss"}')
-              matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "oss"}')
+              matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss", "is_rc": false}')
+              matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "oss", "is_rc": false}')
               ;;
             "Secure Only")
-              matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-qa", "suffix": "-secure", "build_type": "secure"}')
+              if [[ "$IS_RC_BUILD" == "true" ]]; then
+                matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-rc", "suffix": "-secure", "build_type": "secure", "is_rc": true}')
+              else
+                matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-qa", "suffix": "-secure", "build_type": "secure", "is_rc": false}')
+              fi
               ;;
             "Standard OSS Only")
-              matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss"}')
+              matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss", "is_rc": false}')
               ;;
             "Alpine OSS Only")
-              matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "oss"}')
+              matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "oss", "is_rc": false}')
               ;;
           esac
 
@@ -67,6 +82,7 @@ jobs:
           matrix_json="{\"include\":[${matrix_items[*]}]}"
 
           echo "Selected build targets: ${{ inputs.buildTargets }}"
+          echo "Is RC build: $IS_RC_BUILD"
           echo "Generated matrix: $matrix_json"
           echo "matrix=$matrix_json" >> $GITHUB_OUTPUT
 
@@ -518,13 +534,13 @@ jobs:
           platforms: linux/amd64,linux/arm64
           provenance: false
           tags: |
-            ${{ env.REPO_URL }}/${{ matrix.image_name }}:${{ inputs.liquibaseBranch }}
+            ${{ env.REPO_URL }}/${{ matrix.image_name }}:${{ matrix.is_rc == true && inputs.secure-version || inputs.liquibaseBranch }}
           labels: |
             org.opencontainers.image.source=https://github.com/liquibase/docker
             org.opencontainers.image.description=Liquibase QA Container Image${{ matrix.suffix }}
             org.opencontainers.image.licenses=Apache-2.0
             org.opencontainers.image.vendor=Liquibase
-            org.opencontainers.image.version=${{ inputs.liquibaseBranch }}
+            org.opencontainers.image.version=${{ matrix.is_rc == true && inputs.secure-version || inputs.liquibaseBranch }}
             org.opencontainers.image.documentation=https://docs.liquibase.com
             org.opencontainers.image.revision=${{ github.sha }}
             liquibase.branch=${{ inputs.liquibaseBranch }}
@@ -533,7 +549,8 @@ jobs:
         if: ${{ steps.validate-build.outcome == 'success' }}
         run: |
           BUILD_MODE="${{ steps.validate-build.outputs.use_fallback_build == 'true' && 'fallback (standard Dockerfile)' || 'artifact-based' }}"
-          echo "Successfully built and pushed: ${{ env.REPO_URL }}/${{ matrix.image_name }}:${{ inputs.liquibaseBranch }}"
+          IMAGE_TAG="${{ matrix.is_rc == true && inputs.secure-version || inputs.liquibaseBranch }}"
+          echo "Successfully built and pushed: ${{ env.REPO_URL }}/${{ matrix.image_name }}:$IMAGE_TAG"
           echo "Build mode: $BUILD_MODE"
 
       - name: Workflow execution summary
@@ -581,7 +598,8 @@ jobs:
           echo ""
           if [[ "${{ job.status }}" == "success" ]]; then
             echo "🎉 Overall Status: SUCCESS"
-            echo "📦 Image Available: ${{ env.REPO_URL }}/${{ matrix.image_name }}:${{ inputs.liquibaseBranch }}"
+            IMAGE_TAG="${{ matrix.is_rc == true && inputs.secure-version || inputs.liquibaseBranch }}"
+            echo "📦 Image Available: ${{ env.REPO_URL }}/${{ matrix.image_name }}:$IMAGE_TAG"
             if [[ "$USE_FALLBACK" == "true" ]]; then
               echo "ℹ️ Built using fallback mode - standard Dockerfile from branch source"
             fi

--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -24,6 +24,10 @@ on:
           - "Standard OSS Only"
           - "Alpine OSS Only"
         default: "All (OSS + Alpine + Secure)"
+      secure-version:
+        description: "Secure version to use for 'Secure Only' builds (e.g., 5.0.0-RC10). When set, downloads from S3 instead of building from branch."
+        required: false
+        type: string
 
 jobs:
   set-matrix:
@@ -142,9 +146,29 @@ jobs:
           if [[ "${{ matrix.build_type }}" == "secure" ]]; then
             echo "Downloading Liquibase Secure build from S3..."
 
-            # Download Liquibase-Secure build from S3
-            LIQUIBASE_SECURE_ZIP="liquibase-pro-${{ inputs.liquibaseBranch }}.zip"
-            S3_URL="s3://repo.liquibase.com/releases/pro/${{ inputs.liquibaseBranch }}/$LIQUIBASE_SECURE_ZIP"
+            # Determine S3 path based on whether secure-version is provided
+            if [[ -n "${{ inputs.secure-version }}" ]]; then
+              echo "Using secure-version: ${{ inputs.secure-version }}"
+              # Extract base version and RC number for RC versions
+              VERSION="${{ inputs.secure-version }}"
+              if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-RC([0-9]+)$ ]]; then
+                BASE_VERSION="${BASH_REMATCH[1]}"
+                RC_NUMBER="${BASH_REMATCH[2]}"
+                LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.zip"
+                S3_URL="s3://repo.liquibase.com/release-candidates/${BASE_VERSION}/RC${RC_NUMBER}/${LIQUIBASE_SECURE_ZIP}"
+                echo "Using RC S3 path: $S3_URL"
+              else
+                # Regular production version
+                LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.zip"
+                S3_URL="s3://repo.liquibase.com/releases/secure/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
+                echo "Using production S3 path: $S3_URL"
+              fi
+            else
+              echo "Using branch-based build: ${{ inputs.liquibaseBranch }}"
+              # Original branch-based logic
+              LIQUIBASE_SECURE_ZIP="liquibase-secure-${{ inputs.liquibaseBranch }}.zip"
+              S3_URL="s3://repo.liquibase.com/releases/secure/${{ inputs.liquibaseBranch }}/$LIQUIBASE_SECURE_ZIP"
+            fi
 
             echo "Downloading from S3: $S3_URL"
 
@@ -157,10 +181,19 @@ jobs:
                 echo "❌ File exists but access denied. Check permissions."
                 exit 1
               else
-                echo "📦 Liquibase-Secure build not found in S3. Checking if we should trigger workflow or use fallback..."
-                echo "trigger_liquibase_secure_workflow=true" >> $GITHUB_OUTPUT
-                echo "build_ready=false" >> $GITHUB_OUTPUT
-                echo "use_fallback=false" >> $GITHUB_OUTPUT
+                echo "📦 Liquibase-Secure build not found in S3."
+                # If secure-version is provided, don't trigger workflow - the build should exist
+                if [[ -n "${{ inputs.secure-version }}" ]]; then
+                  echo "❌ ERROR: secure-version specified but build not found in S3. Build should already exist for version ${{ inputs.secure-version }}"
+                  echo "trigger_liquibase_secure_workflow=false" >> $GITHUB_OUTPUT
+                  echo "build_ready=false" >> $GITHUB_OUTPUT
+                  echo "use_fallback=true" >> $GITHUB_OUTPUT
+                else
+                  echo "📦 Branch-based build not found. Will trigger workflow to create it..."
+                  echo "trigger_liquibase_secure_workflow=true" >> $GITHUB_OUTPUT
+                  echo "build_ready=false" >> $GITHUB_OUTPUT
+                  echo "use_fallback=false" >> $GITHUB_OUTPUT
+                fi
               fi
             else
               echo "✅ Successfully downloaded Liquibase-Secure build from S3"
@@ -255,7 +288,7 @@ jobs:
         continue-on-error: true
         uses: the-actions-org/workflow-dispatch@v4
         with:
-          workflow: pro-release-to-s3.yml
+          workflow: secure-release-to-s3.yml
           token: ${{ steps.get-token.outputs.token }}
           repo: liquibase/liquibase-pro
           inputs: '{"version": "${{ inputs.liquibaseBranch }}"}'
@@ -268,8 +301,23 @@ jobs:
         if: ${{ matrix.build_type == 'secure' && steps.download-artifact.outputs.trigger_liquibase_secure_workflow == 'true' && steps.download-artifact.outputs.use_fallback != 'true' }}
         id: download-after-trigger
         run: |
-          LIQUIBASE_SECURE_ZIP="liquibase-pro-${{ inputs.liquibaseBranch }}.zip"
-          S3_URL="s3://repo.liquibase.com/releases/pro/${{ inputs.liquibaseBranch }}/$LIQUIBASE_SECURE_ZIP"
+          # Determine S3 path based on whether secure-version is provided (same logic as initial download)
+          if [[ -n "${{ inputs.secure-version }}" ]]; then
+            echo "Using secure-version: ${{ inputs.secure-version }}"
+            VERSION="${{ inputs.secure-version }}"
+            if [[ "$VERSION" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-RC([0-9]+)$ ]]; then
+              BASE_VERSION="${BASH_REMATCH[1]}"
+              RC_NUMBER="${BASH_REMATCH[2]}"
+              LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.zip"
+              S3_URL="s3://repo.liquibase.com/release-candidates/${BASE_VERSION}/RC${RC_NUMBER}/${LIQUIBASE_SECURE_ZIP}"
+            else
+              LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.zip"
+              S3_URL="s3://repo.liquibase.com/releases/secure/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
+            fi
+          else
+            LIQUIBASE_SECURE_ZIP="liquibase-secure-${{ inputs.liquibaseBranch }}.zip"
+            S3_URL="s3://repo.liquibase.com/releases/secure/${{ inputs.liquibaseBranch }}/$LIQUIBASE_SECURE_ZIP"
+          fi
 
           echo "⬇️ Downloading Liquibase Secure build from S3 after workflow completion..."
 
@@ -510,7 +558,7 @@ jobs:
                 echo "   - ✅ Liquibase-Secure build downloaded and Docker image built"
               else
                 echo "   - ❌ Liquibase-Secure workflow may have failed"
-                echo "   - 📋 Check: https://github.com/liquibase/liquibase-pro/actions/workflows/pro-release-to-s3.yml"
+                echo "   - 📋 Check: https://github.com/liquibase/liquibase-pro/actions/workflows/secure-release-to-s3.yml"
               fi
             else
               echo "✅ Build Mode: ARTIFACT-BASED (Direct S3 download)"

--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -74,7 +74,7 @@ jobs:
       matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
     steps:
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -89,7 +89,7 @@ jobs:
 
       - name: Configure AWS credentials for Liquibase-Secure builds
         if: ${{ matrix.build_type == 'secure' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ env.AWS_PROD_GITHUB_OIDC_ROLE_ARN_LIQUIBASE_PRO }}
           aws-region: us-east-1

--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -18,12 +18,12 @@ on:
         required: true
         type: choice
         options:
-          - "All (OSS + Alpine + Pro)"
+          - "All (OSS + Alpine + Secure)"
           - "OSS Only (Standard + Alpine)"
-          - "Pro Only"
+          - "Secure Only"
           - "Standard OSS Only"
           - "Alpine OSS Only"
-        default: "All (OSS + Alpine + Pro)"
+        default: "All (OSS + Alpine + Secure)"
 
 jobs:
   set-matrix:
@@ -38,17 +38,17 @@ jobs:
           matrix_items=()
 
           case "${{ inputs.buildTargets }}" in
-            "All (OSS + Alpine + Pro)")
+            "All (OSS + Alpine + Secure)")
               matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss"}')
               matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "oss"}')
-              matrix_items+=('{"dockerfile": "DockerfilePro", "image_name": "liquibase-pro-qa", "suffix": "-pro", "build_type": "pro"}')
+              matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-qa", "suffix": "-secure", "build_type": "secure"}')
               ;;
             "OSS Only (Standard + Alpine)")
               matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss"}')
               matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "oss"}')
               ;;
-            "Pro Only")
-              matrix_items+=('{"dockerfile": "DockerfilePro", "image_name": "liquibase-pro-qa", "suffix": "-pro", "build_type": "pro"}')
+            "Secure Only")
+              matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-qa", "suffix": "-secure", "build_type": "secure"}')
               ;;
             "Standard OSS Only")
               matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss"}')
@@ -74,7 +74,7 @@ jobs:
       matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
     steps:
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -87,15 +87,15 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
-      - name: Configure AWS credentials for Liquibase Pro builds
-        if: ${{ matrix.build_type == 'pro' }}
-        uses: aws-actions/configure-aws-credentials@v5
+      - name: Configure AWS credentials for Liquibase-Secure builds
+        if: ${{ matrix.build_type == 'secure' }}
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_PROD_GITHUB_OIDC_ROLE_ARN_LIQUIBASE_PRO }}
           aws-region: us-east-1
 
-      - name: Get GitHub App token for Liquibase Pro workflow trigger
-        if: ${{ matrix.build_type == 'pro' }}
+      - name: Get GitHub App token for Liquibase-Secure workflow trigger
+        if: ${{ matrix.build_type == 'secure' }}
         id: get-token
         uses: actions/create-github-app-token@v2
         with:
@@ -107,7 +107,7 @@ jobs:
           permission-actions: write
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Install jq
         run: |
@@ -119,67 +119,59 @@ jobs:
         id: get-workflow-run
         run: |
           # Get the latest successful workflow run for the specified branch
-          echo "🔍 Searching for latest successful workflow run for branch: ${{ inputs.liquibaseBranch }}"
-
-          # Get workflow runs with more detailed filtering
-          WORKFLOW_RUNS_JSON=$(curl -s \
+          WORKFLOW_RUN=$(curl -s \
             -H "Authorization: Bearer ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/liquibase/liquibase/actions/workflows/run-tests.yml/runs?branch=${{ inputs.liquibaseBranch }}&status=completed&per_page=10")
-
-          echo "📊 Analyzing recent workflow runs..."
-          echo "$WORKFLOW_RUNS_JSON" | jq -r '.workflow_runs[] | "ID: \(.id) | Status: \(.status) | Conclusion: \(.conclusion) | Created: \(.created_at)"'
-
-          # Find the first (most recent) workflow run with conclusion=success
-          WORKFLOW_RUN=$(echo "$WORKFLOW_RUNS_JSON" | jq -r '.workflow_runs[] | select(.conclusion == "success") | .id' | head -1)
+            "https://api.github.com/repos/liquibase/liquibase/actions/workflows/run-tests.yml/runs?branch=${{ inputs.liquibaseBranch }}&status=completed&conclusion=success&per_page=1" \
+            | jq -r '.workflow_runs[0].id')
 
           if [ "$WORKFLOW_RUN" = "null" ] || [ -z "$WORKFLOW_RUN" ]; then
-            echo "❌ No successful workflow run found for branch ${{ inputs.liquibaseBranch }}"
+            echo "No successful workflow run found for branch ${{ inputs.liquibaseBranch }}"
             echo "Will build using standard Dockerfile from branch source instead"
             echo "workflow_run_id=" >> $GITHUB_OUTPUT
             echo "has_workflow_run=false" >> $GITHUB_OUTPUT
           else
-            echo "✅ Found latest successful workflow run ID: $WORKFLOW_RUN"
+            echo "Found workflow run ID: $WORKFLOW_RUN"
             echo "workflow_run_id=$WORKFLOW_RUN" >> $GITHUB_OUTPUT
             echo "has_workflow_run=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Download liquibase build artifact (OSS) or from S3 (Liquibase Pro)
+      - name: Download liquibase build artifact (OSS) or from S3 (Liquibase-Secure)
         id: download-artifact
         run: |
-          if [[ "${{ matrix.build_type }}" == "pro" ]]; then
-            echo "Downloading Liquibase Pro build from S3..."
+          if [[ "${{ matrix.build_type }}" == "secure" ]]; then
+            echo "Downloading Liquibase Secure build from S3..."
 
-            # Download Liquibase Pro build from S3
-            LIQUIBASE_PRO_ZIP="liquibase-secure-${{ inputs.liquibaseBranch }}.zip"
-            S3_URL="s3://repo.liquibase.com/releases/secure/${{ inputs.liquibaseBranch }}/$LIQUIBASE_PRO_ZIP"
+            # Download Liquibase-Secure build from S3
+            LIQUIBASE_SECURE_ZIP="liquibase-pro-${{ inputs.liquibaseBranch }}.zip"
+            S3_URL="s3://repo.liquibase.com/releases/pro/${{ inputs.liquibaseBranch }}/$LIQUIBASE_SECURE_ZIP"
 
             echo "Downloading from S3: $S3_URL"
 
             # Try to download from S3 first
-            if ! aws s3 cp "$S3_URL" "$LIQUIBASE_PRO_ZIP" 2>/dev/null; then
-              echo "Failed to download liquibase-pro build from S3. File may not exist yet."
+            if ! aws s3 cp "$S3_URL" "$LIQUIBASE_SECURE_ZIP" 2>/dev/null; then
+              echo "Failed to download liquibase-secure build from S3. File may not exist yet."
 
               # Check if it's a 403/404 error (file doesn't exist)
               if aws s3 ls "$S3_URL" >/dev/null 2>&1; then
                 echo "❌ File exists but access denied. Check permissions."
                 exit 1
               else
-                echo "📦 Liquibase Pro build not found in S3. Checking if we should trigger workflow or use fallback..."
-                echo "trigger_liquibase_pro_workflow=true" >> $GITHUB_OUTPUT
+                echo "📦 Liquibase-Secure build not found in S3. Checking if we should trigger workflow or use fallback..."
+                echo "trigger_liquibase_secure_workflow=true" >> $GITHUB_OUTPUT
                 echo "build_ready=false" >> $GITHUB_OUTPUT
                 echo "use_fallback=false" >> $GITHUB_OUTPUT
               fi
             else
-              echo "✅ Successfully downloaded Liquibase Pro build from S3"
-              echo "trigger_liquibase_pro_workflow=false" >> $GITHUB_OUTPUT
+              echo "✅ Successfully downloaded Liquibase-Secure build from S3"
+              echo "trigger_liquibase_secure_workflow=false" >> $GITHUB_OUTPUT
               echo "build_ready=true" >> $GITHUB_OUTPUT
               echo "use_fallback=false" >> $GITHUB_OUTPUT
 
-              # Extract the liquibase Pro zip
+              # Extract the liquibase Secure zip
               mkdir -p liquibase-build
-              unzip -q "$LIQUIBASE_PRO_ZIP" -d liquibase-build/
-              echo "Liquibase Pro build extracted to liquibase-build/"
+              unzip -q "$LIQUIBASE_SECURE_ZIP" -d liquibase-build/
+              echo "Liquibase Secure build extracted to liquibase-build/"
             fi
 
           else
@@ -257,13 +249,13 @@ jobs:
             ls -la liquibase-build/
           fi
 
-      - name: Trigger Liquibase Pro Release Workflow
-        if: ${{ matrix.build_type == 'pro' && steps.download-artifact.outputs.trigger_liquibase_pro_workflow == 'true' && steps.download-artifact.outputs.use_fallback != 'true' }}
-        id: trigger-liquibase-pro-release
+      - name: Trigger Liquibase Secure Release Workflow
+        if: ${{ matrix.build_type == 'secure' && steps.download-artifact.outputs.trigger_liquibase_secure_workflow == 'true' && steps.download-artifact.outputs.use_fallback != 'true' }}
+        id: trigger-liquibase-secure-release
         continue-on-error: true
         uses: the-actions-org/workflow-dispatch@v4
         with:
-          workflow: secure-release-to-s3.yml
+          workflow: pro-release-to-s3.yml
           token: ${{ steps.get-token.outputs.token }}
           repo: liquibase/liquibase-pro
           inputs: '{"version": "${{ inputs.liquibaseBranch }}"}'
@@ -272,58 +264,58 @@ jobs:
           wait-for-completion-timeout: 60m
           wait-for-completion-interval: 10m
 
-      - name: Download Liquibase Pro build from S3 after workflow completion
-        if: ${{ matrix.build_type == 'pro' && steps.download-artifact.outputs.trigger_liquibase_pro_workflow == 'true' && steps.download-artifact.outputs.use_fallback != 'true' }}
+      - name: Download Liquibase Secure build from S3 after workflow completion
+        if: ${{ matrix.build_type == 'secure' && steps.download-artifact.outputs.trigger_liquibase_secure_workflow == 'true' && steps.download-artifact.outputs.use_fallback != 'true' }}
         id: download-after-trigger
         run: |
-          LIQUIBASE_PRO_ZIP="liquibase-secure-${{ inputs.liquibaseBranch }}.zip"
-          S3_URL="s3://repo.liquibase.com/releases/secure/${{ inputs.liquibaseBranch }}/$LIQUIBASE_PRO_ZIP"
+          LIQUIBASE_SECURE_ZIP="liquibase-pro-${{ inputs.liquibaseBranch }}.zip"
+          S3_URL="s3://repo.liquibase.com/releases/pro/${{ inputs.liquibaseBranch }}/$LIQUIBASE_SECURE_ZIP"
 
-          echo "⬇️ Downloading Liquibase Pro build from S3 after workflow completion..."
-
-          if ! aws s3 cp "$S3_URL" "$LIQUIBASE_PRO_ZIP"; then
-            echo "❌ Failed to download Liquibase Pro build even after workflow completion"
+          echo "⬇️ Downloading Liquibase Secure build from S3 after workflow completion..."
+          
+          if ! aws s3 cp "$S3_URL" "$LIQUIBASE_SECURE_ZIP"; then
+            echo "❌ Failed to download Liquibase Secure build even after workflow completion"
             echo "Will use fallback build from branch source instead"
             echo "build_ready=false" >> $GITHUB_OUTPUT
             echo "use_fallback=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          echo "✅ Successfully downloaded Liquibase Pro build after workflow completion"
+          echo "✅ Successfully downloaded Liquibase Secure build after workflow completion"
 
-          # Extract the liquibase Pro zip
+          # Extract the liquibase Secure zip
           mkdir -p liquibase-build
-          unzip -q "$LIQUIBASE_PRO_ZIP" -d liquibase-build/
+          unzip -q "$LIQUIBASE_SECURE_ZIP" -d liquibase-build/
 
-          echo "Liquibase Pro build extracted to liquibase-build/"
+          echo "Liquibase Secure build extracted to liquibase-build/"
           echo "Contents of liquibase-build:"
           ls -la liquibase-build/
           echo "build_ready=true" >> $GITHUB_OUTPUT
           echo "use_fallback=false" >> $GITHUB_OUTPUT
 
       - name: Validate and prepare liquibase build
-        if: ${{ (matrix.build_type == 'oss' && (steps.download-artifact.outputs.build_ready == 'true' || steps.download-artifact.outputs.use_fallback == 'true')) || matrix.build_type == 'pro' }}
+        if: ${{ (matrix.build_type == 'oss' && (steps.download-artifact.outputs.build_ready == 'true' || steps.download-artifact.outputs.use_fallback == 'true')) || matrix.build_type == 'secure' }}
         id: validate-build
         run: |
           # Determine build mode
           USE_FALLBACK="false"
           if [[ "${{ matrix.build_type }}" == "oss" && "${{ steps.download-artifact.outputs.use_fallback }}" == "true" ]]; then
             USE_FALLBACK="true"
-          elif [[ "${{ matrix.build_type }}" == "pro" ]]; then
-            # Check for Pro fallback conditions
+          elif [[ "${{ matrix.build_type }}" == "secure" ]]; then
+            # Check for Secure fallback conditions
             if [[ "${{ steps.download-artifact.outputs.use_fallback }}" == "true" ]] || [[ "${{ steps.download-after-trigger.outputs.use_fallback }}" == "true" ]]; then
               USE_FALLBACK="true"
-            # Check if Liquibase Pro workflow was triggered but failed
-            elif [[ "${{ steps.download-artifact.outputs.trigger_liquibase_pro_workflow }}" == "true" ]] && [[ "${{ steps.trigger-liquibase-pro-release.outcome }}" == "failure" ]]; then
-              echo "Liquibase Pro workflow trigger failed, falling back to standard Dockerfile build"
+            # Check if Liquibase Secure workflow was triggered but failed
+            elif [[ "${{ steps.download-artifact.outputs.trigger_liquibase_secure_workflow }}" == "true" ]] && [[ "${{ steps.trigger-liquibase-secure-release.outcome }}" == "failure" ]]; then
+              echo "Liquibase Secure workflow trigger failed, falling back to standard Dockerfile build"
               USE_FALLBACK="true"
-            # Check if Liquibase Pro workflow succeeded but download still failed (no build_ready=true from either step)
-            elif [[ "${{ steps.download-artifact.outputs.trigger_liquibase_pro_workflow }}" == "true" ]] && [[ "${{ steps.download-artifact.outputs.build_ready }}" != "true" ]] && [[ "${{ steps.download-after-trigger.outputs.build_ready }}" != "true" ]]; then
-              echo "Liquibase Pro workflow completed but build still not available, falling back to standard Dockerfile build"
+            # Check if Liquibase Secure workflow succeeded but download still failed (no build_ready=true from either step)
+            elif [[ "${{ steps.download-artifact.outputs.trigger_liquibase_secure_workflow }}" == "true" ]] && [[ "${{ steps.download-artifact.outputs.build_ready }}" != "true" ]] && [[ "${{ steps.download-after-trigger.outputs.build_ready }}" != "true" ]]; then
+              echo "Liquibase Secure workflow completed but build still not available, falling back to standard Dockerfile build"
               USE_FALLBACK="true"
             fi
           fi
-
+          
           if [[ "$USE_FALLBACK" == "true" ]]; then
             echo "Using fallback mode - will build from standard Dockerfile using branch source"
             echo "use_fallback_build=true" >> $GITHUB_OUTPUT
@@ -357,8 +349,8 @@ jobs:
           cp "${{ matrix.dockerfile }}" "${{ matrix.dockerfile }}.backup"
 
           # Set version ARG based on dockerfile type
-          if [[ "${{ matrix.dockerfile }}" == "DockerfilePro" ]]; then
-            VERSION_ARG="LIQUIBASE_PRO_VERSION"
+          if [[ "${{ matrix.dockerfile }}" == "DockerfileSecure" ]]; then
+            VERSION_ARG="LIQUIBASE_SECURE_VERSION"
           else
             VERSION_ARG="LIQUIBASE_VERSION"
           fi
@@ -374,23 +366,21 @@ jobs:
           }
 
           # Skip SHA256 ARG lines
-          /^ARG LB_SHA256=/ || /^ARG LB_PRO_SHA256=/ { next }
+          /^ARG LB_SHA256=/ || /^ARG LB_SECURE_SHA256=/ { next }
 
           # Update version ARGs
           /^ARG LIQUIBASE_VERSION=/ { print "ARG LIQUIBASE_VERSION=" branch; next }
-          /^ARG LIQUIBASE_PRO_VERSION=/ { print "ARG LIQUIBASE_PRO_VERSION=" branch; next }
+          /^ARG LIQUIBASE_SECURE_VERSION=/ { print "ARG LIQUIBASE_SECURE_VERSION=" branch; next }
 
           # Handle standard Dockerfile wget block
-          dockerfile == "Dockerfile" && /^RUN wget/ {
+          dockerfile == "Dockerfile" && /^RUN wget.*github\.com.*liquibase.*tar\.gz/ {
             print "# Copy the extracted liquibase build from the build context"
             print "COPY liquibase-build/ ./"
             print ""
-            print "RUN chown -R liquibase:liquibase /liquibase && \\"
-            print "    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
+            print "RUN ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
             print "    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \\"
             print "    liquibase --version"
             in_wget_block = 1
-            # Skip the rest of this line and continue skipping until we find the end
             next
           }
 
@@ -399,35 +389,31 @@ jobs:
             print "# Copy the extracted liquibase build from the build context"
             print "COPY liquibase-build/ ./"
             print ""
-            print "RUN chown -R liquibase:liquibase /liquibase && \\"
-            print "    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
+            print "RUN ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
             print "    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \\"
             print "    liquibase --version"
             in_wget_block = 1
             next
           }
 
-          # Handle Pro Dockerfile wget block (starts with RUN wget but may not have package.liquibase.com on same line)
-          dockerfile == "DockerfilePro" && /^RUN wget/ {
+          # Handle Secure Dockerfile wget block
+          dockerfile == "DockerfileSecure" && /^RUN wget.*repo\.liquibase\.com.*tar\.gz/ {
             print "# Copy the extracted liquibase build from the build context"
             print "COPY liquibase-build/ ./"
             print ""
-            print "RUN chown -R liquibase:liquibase /liquibase && \\"
-            print "    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
+            print "RUN ln -s /liquibase/liquibase /usr/local/bin/liquibase && \\"
             print "    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \\"
             print "    liquibase --version"
             in_wget_block = 1
             next
           }
 
-          # Skip all lines in the wget block until we find the end marker
-          in_wget_block == 1 {
-            # Look for the end of the RUN block (line ending without backslash, and contains version check)
-            if (/liquibase --version/ && !/\\\\$/) {
-              in_wget_block = 0
-            }
+          # Skip lines until we reach the end of wget block
+          in_wget_block == 1 && /liquibase --version/ {
+            in_wget_block = 0
             next
           }
+          in_wget_block == 1 { next }
 
           # Print all other lines
           { print }
@@ -448,13 +434,6 @@ jobs:
           echo "First 30 lines of modified ${{ matrix.dockerfile }}:"
           head -30 "${{ matrix.dockerfile }}"
           echo "..."
-
-      - name: Print modified Dockerfile
-        if: ${{ steps.validate-build.outputs.use_fallback_build == 'false' }}
-        run: |
-          echo "=== Complete modified ${{ matrix.dockerfile }} content ==="
-          cat "${{ matrix.dockerfile }}"
-          echo "=== End of ${{ matrix.dockerfile }} ==="
 
       - name: Set up Docker Buildx
         if: ${{ steps.validate-build.outcome == 'success' }}
@@ -521,21 +500,21 @@ jobs:
             echo "   - No pre-built artifacts were available"
             echo "   - Used standard Dockerfile without modification"
             echo "   - Built directly from liquibase branch: ${{ inputs.liquibaseBranch }}"
-          elif [[ "${{ matrix.build_type }}" == "pro" ]]; then
-            if [[ "${{ steps.download-artifact.outputs.trigger_liquibase_pro_workflow }}" == "true" ]]; then
-              echo "🔄 Build Mode: ARTIFACT-BASED (Pro workflow triggered)"
+          elif [[ "${{ matrix.build_type }}" == "secure" ]]; then
+            if [[ "${{ steps.download-artifact.outputs.trigger_liquibase_secure_workflow }}" == "true" ]]; then
+              echo "🔄 Build Mode: ARTIFACT-BASED (Secure workflow triggered)"
               echo "   - S3 build was missing for branch ${{ inputs.liquibaseBranch }}"
               echo "   - Automatically triggered pro-release-to-s3.yml workflow"
               if [[ "${{ steps.download-after-trigger.outputs.build_ready }}" == "true" ]]; then
-                echo "   - ✅ Liquibase Pro workflow completed successfully"
-                echo "   - ✅ Liquibase Pro build downloaded and Docker image built"
+                echo "   - ✅ Liquibase-Secure workflow completed successfully"
+                echo "   - ✅ Liquibase-Secure build downloaded and Docker image built"
               else
-                echo "   - ❌ Liquibase Pro workflow may have failed"
+                echo "   - ❌ Liquibase-Secure workflow may have failed"
                 echo "   - 📋 Check: https://github.com/liquibase/liquibase-pro/actions/workflows/pro-release-to-s3.yml"
               fi
             else
               echo "✅ Build Mode: ARTIFACT-BASED (Direct S3 download)"
-              echo "   - Liquibase Pro build downloaded from S3"
+              echo "   - Liquibase-Secure build downloaded from S3"
             fi
           else
             echo "✅ Build Mode: ARTIFACT-BASED (GitHub artifact)"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,7 +5,7 @@ permissions:
   pull-requests: write
   id-token: write
   packages: write
-  
+
 on:
   repository_dispatch:
     types: [liquibase-release, liquibase-secure-release]
@@ -51,7 +51,7 @@ on:
 jobs:
   update-dockerfiles:
     env:
-      LPM_VERSION: "0.2.10"
+      LPM_VERSION: "0.2.12"
     name: "Update Dockerfiles"
     runs-on: ubuntu-latest
     outputs:
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Collect Data
         id: collect-data
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             function getMinorVersion(version) {
@@ -139,7 +139,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-contents: write
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           ref: ${{ github.ref }}
@@ -147,7 +147,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "8"
           distribution: "adopt"
@@ -156,14 +156,14 @@ jobs:
         run: |
           git config user.name "liquibot"
           git config user.email "liquibot@liquibase.org"
-      
+
       - name: Update Dockerfile(s) and commit changes
         id: update-dockerfiles
         run: |
           # First ensure we're up to date with remote
           git fetch origin
           git reset --hard origin/${{ github.ref_name }}
-          
+
           if [[ "${{ steps.collect-data.outputs.releaseType }}" == "liquibase-secure-release" ]]; then
             file_list=("DockerfileSecure")
             LIQUIBASE_SECURE_SHA=$(curl -LsS https://repo.liquibase.com/releases/pro/${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-pro-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }')
@@ -213,7 +213,7 @@ jobs:
           VERSION="${{ steps.collect-data.outputs.liquibaseVersion }}"
           EXTENSION_VERSION="${{ steps.collect-data.outputs.extensionVersion }}"
           RELEASE_TYPE="${{ steps.collect-data.outputs.releaseType }}"
-          
+
           if [[ "${RELEASE_TYPE}" == "liquibase-secure-release" ]]; then
             TAG_NAME="v${VERSION}-SECURE"
             COMMIT_MSG="Liquibase Secure Version Bumped to ${VERSION}"
@@ -223,7 +223,7 @@ jobs:
             COMMIT_MSG="Liquibase Version Bumped to ${EXTENSION_VERSION}"
             TAG_MSG="Version Bumped to ${EXTENSION_VERSION}"
           fi
-          
+
           # Create and push new tag
           git tag -a -m "${TAG_MSG}" "${TAG_NAME}"
           # Push changes and tags using the token
@@ -263,7 +263,7 @@ jobs:
             latest_tag: "latest"
             type: liquibase-secure-release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           ref: ${{ github.ref }}
@@ -288,7 +288,7 @@ jobs:
           echo "DOCKERHUB_USERNAME_DECODED=$decoded_username" >> $GITHUB_ENV
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "8"
           distribution: "adopt"
@@ -489,9 +489,9 @@ jobs:
           permission-contents: write
           permission-actions: write
           permission-pull-requests: write
-                
+
       - name: Check out liquibase/official-images
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: liquibase/official-images
           ref: master
@@ -545,7 +545,7 @@ jobs:
 
   trigger-aws-marketplace-listing:
     runs-on: ubuntu-latest
-    needs: [ update-dockerfiles, setup-update-draft-build ]
+    needs: [update-dockerfiles, setup-update-draft-build]
     steps:
       - name: Trigger AWS Marketplace Listing
         uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,7 +8,7 @@ permissions:
   
 on:
   repository_dispatch:
-    types: [liquibase-release, liquibase-pro-release]
+    types: [liquibase-release, liquibase-secure-release]
   workflow_dispatch:
     inputs:
       releaseType:
@@ -18,7 +18,7 @@ on:
         type: choice
         options:
           - liquibase-release
-          - liquibase-pro-release
+          - liquibase-secure-release
       liquibaseVersion:
         description: "Liquibase Version"
         required: true
@@ -51,7 +51,7 @@ on:
 jobs:
   update-dockerfiles:
     env:
-      LPM_VERSION: "0.2.12"
+      LPM_VERSION: "0.2.10"
     name: "Update Dockerfiles"
     runs-on: ubuntu-latest
     outputs:
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Collect Data
         id: collect-data
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             function getMinorVersion(version) {
@@ -117,7 +117,7 @@ jobs:
           echo "Dry run: ${{ steps.collect-data.outputs.dryRun }}"
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -139,7 +139,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-contents: write
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ github.ref }}
@@ -147,7 +147,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: "8"
           distribution: "adopt"
@@ -164,14 +164,14 @@ jobs:
           git fetch origin
           git reset --hard origin/${{ github.ref_name }}
           
-          if [[ "${{ steps.collect-data.outputs.releaseType }}" == "liquibase-pro-release" ]]; then
-            file_list=("DockerfilePro")
-            LIQUIBASE_PRO_SHA=$(curl -LsS https://repo.liquibase.com/releases/pro/${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-pro-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }')
+          if [[ "${{ steps.collect-data.outputs.releaseType }}" == "liquibase-secure-release" ]]; then
+            file_list=("DockerfileSecure")
+            LIQUIBASE_SECURE_SHA=$(curl -LsS https://repo.liquibase.com/releases/pro/${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-pro-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }')
             LPM_SHA=$(curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip | sha256sum | awk '{ print $1 }')
             LPM_SHA_ARM=$(curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux-arm64.zip | sha256sum | awk '{ print $1 }')
             for file in "${file_list[@]}"; do
-              sed -i 's/^ARG LIQUIBASE_PRO_VERSION=.*/ARG LIQUIBASE_PRO_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' "${{ github.workspace }}/${file}"
-              sed -i 's/^ARG LB_PRO_SHA256=.*/ARG LB_PRO_SHA256='"$LIQUIBASE_PRO_SHA"'/' "${{ github.workspace }}/${file}"
+              sed -i 's/^ARG LIQUIBASE_SECURE_VERSION=.*/ARG LIQUIBASE_SECURE_VERSION='"${{ steps.collect-data.outputs.liquibaseVersion }}"'/' "${{ github.workspace }}/${file}"
+              sed -i 's/^ARG LB_SECURE_SHA256=.*/ARG LB_SECURE_SHA256='"$LIQUIBASE_SECURE_SHA"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LPM_SHA256=.*/ARG LPM_SHA256='"$LPM_SHA"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
               git add "${file}"
@@ -180,7 +180,7 @@ jobs:
               echo "Nothing new to commit"
               echo "changes_made=false" >> $GITHUB_OUTPUT
             else
-              COMMIT_MSG="Liquibase Pro Version Bumped to ${{ steps.collect-data.outputs.liquibaseVersion }}"
+              COMMIT_MSG="Liquibase Secure Version Bumped to ${{ steps.collect-data.outputs.liquibaseVersion }}"
               git commit -m "${COMMIT_MSG}"
               echo "changes_made=true" >> $GITHUB_OUTPUT
             fi
@@ -214,10 +214,10 @@ jobs:
           EXTENSION_VERSION="${{ steps.collect-data.outputs.extensionVersion }}"
           RELEASE_TYPE="${{ steps.collect-data.outputs.releaseType }}"
           
-          if [[ "${RELEASE_TYPE}" == "liquibase-pro-release" ]]; then
-            TAG_NAME="v${VERSION}-PRO"
-            COMMIT_MSG="Liquibase Pro Version Bumped to ${VERSION}"
-            TAG_MSG="Version Bumped to ${VERSION} Pro"
+          if [[ "${RELEASE_TYPE}" == "liquibase-secure-release" ]]; then
+            TAG_NAME="v${VERSION}-SECURE"
+            COMMIT_MSG="Liquibase Secure Version Bumped to ${VERSION}"
+            TAG_MSG="Version Bumped to ${VERSION} Secure"
           else
             TAG_NAME="v${EXTENSION_VERSION}"
             COMMIT_MSG="Liquibase Version Bumped to ${EXTENSION_VERSION}"
@@ -257,19 +257,19 @@ jobs:
             suffix: "-alpine"
             latest_tag: "alpine"
             type: liquibase-release
-          - dockerfile: DockerfilePro
-            name: liquibase/liquibase-pro
+          - dockerfile: DockerfileSecure
+            name: liquibase/liquibase-secure
             suffix: ""
             latest_tag: "latest"
-            type: liquibase-pro-release
+            type: liquibase-secure-release
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ github.ref }}
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -288,20 +288,20 @@ jobs:
           echo "DOCKERHUB_USERNAME_DECODED=$decoded_username" >> $GITHUB_ENV
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: "8"
           distribution: "adopt"
 
       - name: Release Notes
-        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && ((needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release') || (needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && matrix.type == 'liquibase-pro-release')) }}
+        if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && ((needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release') || (needs.update-dockerfiles.outputs.releaseType == 'liquibase-secure-release' && matrix.type == 'liquibase-secure-release')) }}
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && format('v{0} PRO', needs.update-dockerfiles.outputs.extensionVersion) || format('v{0}', needs.update-dockerfiles.outputs.extensionVersion) }}
+          name: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-secure-release' && format('v{0} SECURE', needs.update-dockerfiles.outputs.extensionVersion) || format('v{0}', needs.update-dockerfiles.outputs.extensionVersion) }}
           tag_name: v${{ needs.update-dockerfiles.outputs.extensionVersion }}
           draft: true
           body: |
-            ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-pro-release' && format('Support for Liquibase Pro {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) || format('Support for Liquibase {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) }}
+            ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-secure-release' && format('Support for Liquibase Secure {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) || format('Support for Liquibase {0}.', needs.update-dockerfiles.outputs.liquibaseVersion) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -316,10 +316,10 @@ jobs:
             echo "DOCKERHUB_REPO=${{ matrix.name }}" >> $GITHUB_OUTPUT
             echo "ECR_REPO=public.ecr.aws/liquibase/liquibase" >> $GITHUB_OUTPUT
             echo "GHCR_REPO=ghcr.io/liquibase/liquibase" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.type }}" == "liquibase-pro-release" ]]; then
+          elif [[ "${{ matrix.type }}" == "liquibase-secure-release" ]]; then
             echo "DOCKERHUB_REPO=${{ matrix.name }}" >> $GITHUB_OUTPUT
-            echo "ECR_REPO=public.ecr.aws/liquibase/liquibase-pro" >> $GITHUB_OUTPUT
-            echo "GHCR_REPO=ghcr.io/liquibase/liquibase-pro" >> $GITHUB_OUTPUT
+            echo "ECR_REPO=public.ecr.aws/liquibase/liquibase-secure" >> $GITHUB_OUTPUT
+            echo "GHCR_REPO=ghcr.io/liquibase/liquibase-secure" >> $GITHUB_OUTPUT
           fi
 
       # Use separate login steps for each registry
@@ -340,7 +340,7 @@ jobs:
 
       - name: Configure AWS credentials for PROD ECR
         id: configure-aws-credentials-prod
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_PROD_GITHUB_OIDC_ROLE_ARN_INFRASTRUCTURE }}
           aws-region: us-east-1
@@ -437,7 +437,7 @@ jobs:
           # Labels applied to each architecture-specific image
           labels: |
             org.opencontainers.image.source=https://github.com/liquibase/docker
-            org.opencontainers.image.description=${{ matrix.type == 'liquibase-pro-release' && 'Liquibase Pro Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
+            org.opencontainers.image.description=${{ matrix.type == 'liquibase-secure-release' && 'Liquibase Secure Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
             org.opencontainers.image.licenses=Apache-2.0
             org.opencontainers.image.vendor=Liquibase
             org.opencontainers.image.version=${{ needs.update-dockerfiles.outputs.extensionVersion }}
@@ -445,7 +445,7 @@ jobs:
           # Annotations applied to the manifest list (important for multi-arch images)
           annotations: |
             org.opencontainers.image.source=https://github.com/liquibase/docker
-            org.opencontainers.image.description=${{ matrix.type == 'liquibase-pro-release' && 'Liquibase Pro Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
+            org.opencontainers.image.description=${{ matrix.type == 'liquibase-secure-release' && 'Liquibase Secure Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
             org.opencontainers.image.licenses=Apache-2.0
             org.opencontainers.image.vendor=Liquibase
             org.opencontainers.image.version=${{ needs.update-dockerfiles.outputs.extensionVersion }}
@@ -466,7 +466,7 @@ jobs:
           echo "MAJOR_MINOR: ${VERSION%.*}"
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -491,7 +491,7 @@ jobs:
           permission-pull-requests: write
                 
       - name: Check out liquibase/official-images
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           repository: liquibase/official-images
           ref: master
@@ -542,3 +542,14 @@ jobs:
 
       - name: Adding Official Docker PR to job summary
         run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY
+
+  trigger-aws-marketplace-listing:
+    runs-on: ubuntu-latest
+    needs: [ update-dockerfiles, setup-update-draft-build ]
+    steps:
+      - name: Trigger AWS Marketplace Listing
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: trigger-aws-marketplace-listing
+          repository: liquibase/liquibase-aws-license-service

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -166,7 +166,7 @@ jobs:
 
           if [[ "${{ steps.collect-data.outputs.releaseType }}" == "liquibase-secure-release" ]]; then
             file_list=("DockerfileSecure")
-            LIQUIBASE_SECURE_SHA=$(curl -LsS https://repo.liquibase.com/releases/pro/${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-pro-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }')
+            LIQUIBASE_SECURE_SHA=$(curl -LsS https://repo.liquibase.com/releases/secure/${{ steps.collect-data.outputs.liquibaseVersion }}/liquibase-secure-${{ steps.collect-data.outputs.liquibaseVersion }}.tar.gz | sha256sum | awk '{ print $1 }')
             LPM_SHA=$(curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux.zip | sha256sum | awk '{ print $1 }')
             LPM_SHA_ARM=$(curl -LsS https://github.com/liquibase/liquibase-package-manager/releases/download/v${{ env.LPM_VERSION }}/lpm-${{ env.LPM_VERSION }}-linux-arm64.zip | sha256sum | awk '{ print $1 }')
             for file in "${file_list[@]}"; do

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -117,7 +117,7 @@ jobs:
           echo "Dry run: ${{ steps.collect-data.outputs.dryRun }}"
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -269,7 +269,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
@@ -340,7 +340,7 @@ jobs:
 
       - name: Configure AWS credentials for PROD ECR
         id: configure-aws-credentials-prod
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ env.AWS_PROD_GITHUB_OIDC_ROLE_ARN_INFRASTRUCTURE }}
           aws-region: us-east-1
@@ -466,7 +466,7 @@ jobs:
           echo "MAJOR_MINOR: ${VERSION%.*}"
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/publish-liquibase-secure-readme.yml
+++ b/.github/workflows/publish-liquibase-secure-readme.yml
@@ -1,8 +1,9 @@
-name: Publish Liquibase Pro README to Docker Hub
+name: Publish Liquibase Secure README to Docker Hub
 
 on:
   push:
     paths:
+      - 'README-secure.md'
       - 'README-pro.md'
     branches:
       - main
@@ -13,7 +14,7 @@ permissions:
   id-token: write
   
 jobs:
-  update-liquibase-pro-readme:
+  update-liquibase-secure-readme:
     runs-on: ubuntu-latest
     
     steps:
@@ -39,11 +40,11 @@ jobs:
           decoded_username=$(echo "${{ env.DOCKERHUB_USERNAME }}" | base64 -d)
           echo "DOCKERHUB_USERNAME_DECODED=$decoded_username" >> $GITHUB_ENV
 
-      - name: Update Liquibase Pro README on Docker Hub
+      - name: Update Liquibase Secure README on Docker Hub
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ env.DOCKERHUB_USERNAME_DECODED }}
           password: ${{ env.DOCKERHUB_UPDATE_README }}
           repository: liquibase/liquibase-pro
-          readme-filepath: ./README-pro.md
-          short-description: "Liquibase Pro"
+          readme-filepath: ./README-secure.md
+          short-description: "Liquibase Secure"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dockerfile: [Dockerfile, Dockerfile.alpine, DockerfilePro]
+        dockerfile: [Dockerfile, Dockerfile.alpine, DockerfileSecure]
         os: [ubuntu-latest, macos-13]
 
     name: Build & Test ${{ matrix.dockerfile }} - ${{ matrix.os }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,7 +30,7 @@ jobs:
         image: [ 
           {dockerfile: Dockerfile, name: liquibase/liquibase, suffix: ""},
           {dockerfile: Dockerfile.alpine, name: liquibase/liquibase, suffix: "-alpine"},
-          {dockerfile: DockerfilePro, name: liquibase/liquibase-pro, suffix: "-pro"},
+          {dockerfile: DockerfileSecure, name: liquibase/liquibase-pro, suffix: "-secure"},
           ]
     name: Trivy
     runs-on: "ubuntu-22.04"
@@ -110,7 +110,7 @@ jobs:
         image: [ 
           {dockerfile: Dockerfile, name: liquibase/liquibase, suffix: ""},
           {dockerfile: Dockerfile.alpine, name: liquibase/liquibase, suffix: "-alpine"},
-          {dockerfile: DockerfilePro, name: liquibase/liquibase-pro, suffix: "-pro"},
+          {dockerfile: DockerfileSecure, name: liquibase/liquibase-pro, suffix: "-secure"},
           ]
     name: Scout
     runs-on: "ubuntu-22.04"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is the official Liquibase Docker image repository that builds and publishes Docker images for both Liquibase OSS and Liquibase Pro editions. The repository contains:
+This is the official Liquibase Docker image repository that builds and publishes Docker images for both Liquibase OSS and Liquibase Secure editions. The repository contains:
 
 - **Dockerfile**: Standard Liquibase OSS image
-- **DockerfilePro**: Liquibase Pro image (enterprise features)
+- **DockerfileSecure**: Liquibase Secure image (enterprise features)
 - **Dockerfile.alpine**: Alpine Linux variant (lightweight)
 - **Examples**: Database-specific extensions (AWS CLI, SQL Server, PostgreSQL, Oracle)
 - **Docker Compose**: Complete example with PostgreSQL
@@ -15,7 +15,7 @@ This is the official Liquibase Docker image repository that builds and publishes
 ## Image Publishing
 
 Images are published to multiple registries:
-- Docker Hub: `liquibase/liquibase` (OSS) and `liquibase/liquibase-pro` (Pro)
+- Docker Hub: `liquibase/liquibase` (OSS) and `liquibase/liquibase-secure` (Secure)
 - GitHub Container Registry: `ghcr.io/liquibase/liquibase*`
 - Amazon ECR Public: `public.ecr.aws/liquibase/liquibase*`
 
@@ -27,8 +27,8 @@ Images are published to multiple registries:
 # Build OSS image
 docker build -f Dockerfile -t liquibase/liquibase:latest .
 
-# Build Pro image
-docker build -f DockerfilePro -t liquibase/liquibase-pro:latest .
+# Build Secure image
+docker build -f DockerfileSecure -t liquibase/liquibase-secure:latest .
 
 # Build Alpine variant
 docker build -f Dockerfile.alpine -t liquibase/liquibase:latest-alpine .
@@ -40,8 +40,8 @@ docker build -f Dockerfile.alpine -t liquibase/liquibase:latest-alpine .
 # Test OSS image
 docker run --rm liquibase/liquibase:latest --version
 
-# Test Pro image (requires license)
-docker run --rm -e LIQUIBASE_LICENSE_KEY="your-key" liquibase/liquibase-pro:latest --version
+# Test Secure image (requires license)
+docker run --rm -e LIQUIBASE_LICENSE_KEY="your-key" liquibase/liquibase-secure:latest --version
 
 # Run with example changelog
 docker run --rm -v $(pwd)/examples/docker-compose/changelog:/liquibase/changelog liquibase/liquibase:latest --changelog-file=db.changelog-master.xml validate
@@ -57,8 +57,8 @@ docker-compose up
 # Use local build for testing
 docker-compose -f docker-compose.local.yml up --build
 
-# Run with Liquibase Pro
-docker-compose -f docker-compose.pro.yml up
+# Run with Liquibase Secure
+docker-compose -f docker-compose.secure.yml up
 ```
 
 ## Architecture
@@ -70,13 +70,13 @@ docker-compose -f docker-compose.pro.yml up
 - **Entrypoint**: `docker-entrypoint.sh` with automatic MySQL driver installation
 
 ### Key Components
-- **Liquibase**: Database migration tool (OSS: GitHub releases, Pro: repo.liquibase.com)
+- **Liquibase**: Database migration tool (OSS: GitHub releases, Secure: repo.liquibase.com)
 - **LPM**: Liquibase Package Manager for extensions
 - **Default Config**: `liquibase.docker.properties` sets headless mode
 - **CLI-Docker Compatibility**: Auto-detects `/liquibase/changelog` mount and changes working directory for consistent behavior
 
 ### Version Management
-- Liquibase versions are controlled via `LIQUIBASE_VERSION` (OSS) and `LIQUIBASE_PRO_VERSION` (Pro) ARGs
+- Liquibase versions are controlled via `LIQUIBASE_VERSION` (OSS) and `LIQUIBASE_PRO_VERSION` (Secure) ARGs
 - SHA256 checksums are validated for security
 - LPM version is specified via `LPM_VERSION` ARG
 
@@ -88,8 +88,8 @@ docker-compose -f docker-compose.pro.yml up
 - `LIQUIBASE_COMMAND_PASSWORD`: Database password
 - `LIQUIBASE_COMMAND_CHANGELOG_FILE`: Path to changelog file
 
-### Pro Features (DockerfilePro only)
-- `LIQUIBASE_LICENSE_KEY`: Required for Pro features
+### Secure Features (DockerfileSecure only)
+- `LIQUIBASE_LICENSE_KEY`: Required for Secure features
 - `LIQUIBASE_PRO_POLICY_CHECKS_ENABLED`: Enable policy checks
 - `LIQUIBASE_PRO_QUALITY_CHECKS_ENABLED`: Enable quality checks
 
@@ -107,9 +107,9 @@ FROM liquibase/liquibase:latest
 RUN lpm add mysql --global
 ```
 
-### Using Liquibase Pro
+### Using Liquibase Secure
 ```dockerfile
-FROM liquibase/liquibase-pro:latest
+FROM liquibase/liquibase-secure:latest
 ENV LIQUIBASE_LICENSE_KEY=your-license-key
 ```
 

--- a/DockerfileSecure
+++ b/DockerfileSecure
@@ -9,28 +9,26 @@ RUN groupadd --gid 1001 liquibase && \
 # Download and install Liquibase
 WORKDIR /liquibase
 
-ARG LIQUIBASE_PRO_VERSION=4.33.0
-ARG LB_PRO_SHA256=f36d71194927a1fea1325f0ce17e1995b169a2a6d4de3166797230cb01791b0d
+ARG LIQUIBASE_SECURE_VERSION=4.33.0
+ARG LB_SECURE_SHA256=f36d71194927a1fea1325f0ce17e1995b169a2a6d4de3166797230cb01791b0d
 
 # Add metadata labels
-LABEL org.opencontainers.image.description="Liquibase Pro Container Image"
+LABEL org.opencontainers.image.description="Liquibase Secure Container Image"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.vendor="Liquibase"
-LABEL org.opencontainers.image.version="${LIQUIBASE_PRO_VERSION}"
+LABEL org.opencontainers.image.version="${LIQUIBASE_SECURE_VERSION}"
 LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"
 
 # Download and install Liquibase
 WORKDIR /liquibase
 
-RUN wget -q -O liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz \
-  "https://package.liquibase.com/downloads/dockerhub/official/liquibase-pro-${LIQUIBASE_PRO_VERSION}" && \
-  echo "$LB_PRO_SHA256 *liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz" | sha256sum -c - && \
-  tar -xzf liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz && \
-  rm liquibase-pro-${LIQUIBASE_PRO_VERSION}.tar.gz && \
-  ln -s /liquibase/liquibase /usr/local/bin/liquibase && \
-  ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
-  liquibase --version
-
+RUN wget -q -O liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz "https://repo.liquibase.com/releases/pro/${LIQUIBASE_SECURE_VERSION}/liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz" && \
+    echo "$LB_SECURE_SHA256 *liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz" | sha256sum -c - && \
+    tar -xzf liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz && \
+    rm liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz && \
+    ln -s /liquibase/liquibase /usr/local/bin/liquibase && \
+    ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
+    liquibase --version
     
 ARG LPM_VERSION=0.2.12
 ARG LPM_SHA256=93748cc512761fd0a77cdf556b02519b7d9ab47f3b547aa394b6e3a02576c5d2

--- a/DockerfileSecure
+++ b/DockerfileSecure
@@ -22,10 +22,10 @@ LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"
 # Download and install Liquibase
 WORKDIR /liquibase
 
-RUN wget -q -O liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz "https://repo.liquibase.com/releases/pro/${LIQUIBASE_SECURE_VERSION}/liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz" && \
-    echo "$LB_SECURE_SHA256 *liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz" | sha256sum -c - && \
-    tar -xzf liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz && \
-    rm liquibase-pro-${LIQUIBASE_SECURE_VERSION}.tar.gz && \
+RUN wget -q -O liquibase-secure-${LIQUIBASE_SECURE_VERSION}.tar.gz "https://repo.liquibase.com/releases/secure/${LIQUIBASE_SECURE_VERSION}/liquibase-secure-${LIQUIBASE_SECURE_VERSION}.tar.gz" && \
+    echo "$LB_SECURE_SHA256 *liquibase-secure-${LIQUIBASE_SECURE_VERSION}.tar.gz" | sha256sum -c - && \
+    tar -xzf liquibase-secure-${LIQUIBASE_SECURE_VERSION}.tar.gz && \
+    rm liquibase-secure-${LIQUIBASE_SECURE_VERSION}.tar.gz && \
     ln -s /liquibase/liquibase /usr/local/bin/liquibase && \
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version

--- a/README-secure.md
+++ b/README-secure.md
@@ -1,27 +1,19 @@
-# ⚠️ Docker Image Name Change
-> The official Docker image formerly known as **`liquibase-pro`** (i.e. `liquibase/liquibase-pro`) has been renamed to **`liquibase-secure`** (`liquibase/liquibase-secure`).  
-> Existing functionality remains unchanged — just update your Docker pull or run commands to reflect the new image name.
->
-> **Examples:**
-> - Old: `docker pull liquibase/liquibase-pro:TAG`  
-> - New: `docker pull liquibase/liquibase-secure:TAG`
+# Official Liquibase-Secure Docker Images formerly called Liquibase-Pro
 
-# Official Liquibase-Pro Docker Images
-
-**Liquibase Pro** is the enterprise edition of Liquibase that provides advanced database DevOps capabilities for teams requiring enhanced security, performance, and governance features.
+**Liquibase Secure** is the enterprise edition of Liquibase that provides advanced database DevOps capabilities for teams requiring enhanced security, performance, and governance features.
 
 ## ⚠️ License Requirements
 
-> **WARNING**: Liquibase Pro requires a valid license key to use Pro features. Without a license, the container will run in Liquibase Community mode with limited functionality.
+> **WARNING**: Liquibase Secure requires a valid license key to use Secure features. Without a license, the container will run in Liquibase Community mode with limited functionality.
 >
-> - Contact [Liquibase Sales](https://www.liquibase.com/community/contact) to obtain a Pro license
-> - Existing customers receive their Pro license keys in an email.
+> - Contact [Liquibase Sales](https://www.liquibase.com/community/contact) to obtain a Liquibase Secure license
+> - Existing customers receive their Secure license keys in an email.
 
-## 📋 Pro Features
+## 📋 Secure Features
 
-Liquibase Pro is the enterprise edition of [Liquibase](https://www.liquibase.com/) that provides advanced database DevOps capabilities for teams requiring enhanced security, performance, and governance features.
+Liquibase Secure is the enterprise edition of [Liquibase](https://www.liquibase.com/) that provides advanced database DevOps capabilities for teams requiring enhanced security, performance, and governance features.
 
-Liquibase Pro includes all Community features plus:
+Liquibase Secure includes all Community features plus:
 
 ### 🔐 Security & Governance
 
@@ -35,11 +27,11 @@ Liquibase Pro includes all Community features plus:
 
 ## 🔧 Environment Variables
 
-### Pro License Environment Variable
+### Secure License Environment Variable
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `LIQUIBASE_LICENSE_KEY` | Your Liquibase Pro license key | `ABcd-1234-EFGH-5678` |
+| `LIQUIBASE_LICENSE_KEY` | Your Liquibase Secure license key | `ABcd-1234-EFGH-5678` |
 
 ### 🔧 Action Required
 
@@ -49,58 +41,58 @@ Please update your Dockerfiles and scripts to pull from the new official image:
 
 We publish this image to multiple registries:
 
-| Registry | Pro Image |
+| Registry | Secure Image |
 |----------|-----------|
-| **Docker Hub (default)** | `liquibase/liquibase-pro` |
-| **GitHub Container Registry** | `ghcr.io/liquibase/liquibase-pro` |
-| **Amazon ECR Public** | `public.ecr.aws/liquibase/liquibase-pro` |
+| **Docker Hub (default)** | `liquibase/liquibase-secure` |
+| **GitHub Container Registry** | `ghcr.io/liquibase/liquibase-secure` |
+| **Amazon ECR Public** | `public.ecr.aws/liquibase/liquibase-secure` |
 
 ## Dockerfile
 
 ```dockerfile
-FROM liquibase/liquibase-pro:latest
-# OR ghcr.io/liquibase/liquibase-pro:latest    # GHCR  
-# OR public.ecr.aws/liquibase/liquibase-pro:latest   # Amazon ECR Public
+FROM liquibase/liquibase-secure:latest
+# OR ghcr.io/liquibase/liquibase-secure:latest    # GHCR  
+# OR public.ecr.aws/liquibase/liquibase-secure:latest   # Amazon ECR Public
 ```
 
 ## Scripts
 
-### Pro Edition
+### Liquibase Secure Edition
 
 ```bash
 # Docker Hub (default)
-docker pull liquibase/liquibase-pro
+docker pull liquibase/liquibase-secure
 
 # GitHub Container Registry
-docker pull ghcr.io/liquibase/liquibase-pro
+docker pull ghcr.io/liquibase/liquibase-secure
 
 # Amazon ECR Public
-docker pull public.ecr.aws/liquibase/liquibase-pro
+docker pull public.ecr.aws/liquibase/liquibase-secure
 ```
 
 ### Pulling the Latest or Specific Version
 
-#### Pulling Pro Edition Images
+#### Pulling Liquibase Secure Edition Images
 
 ```bash
 # Latest
-docker pull liquibase/liquibase-pro:latest
-docker pull ghcr.io/liquibase/liquibase-pro:latest
-docker pull public.ecr.aws/liquibase/liquibase-pro:latest
+docker pull liquibase/liquibase-secure:latest
+docker pull ghcr.io/liquibase/liquibase-secure:latest
+docker pull public.ecr.aws/liquibase/liquibase-secure:latest
 
 # Specific version (example: 4.32.0)
-docker pull liquibase/liquibase-pro:4.32.0
-docker pull ghcr.io/liquibase/liquibase-pro:4.32.0
-docker pull public.ecr.aws/liquibase/liquibase-pro:4.32.0
+docker pull liquibase/liquibase-secure:4.32.0
+docker pull ghcr.io/liquibase/liquibase-secure:4.32.0
+docker pull public.ecr.aws/liquibase/liquibase-secure:4.32.0
 ```
 
 For any questions or support, please visit our [Liquibase Community Forum](https://forum.liquibase.org/).
 
 ## 🏷️ Supported Tags
 
-The following tags are officially supported and can be found on [Docker Hub](https://hub.docker.com/r/liquibase/liquibase-pro/tags):
+The following tags are officially supported and can be found on [Docker Hub](https://hub.docker.com/r/liquibase/liquibase-secure/tags):
 
-- `liquibase/liquibase-pro:<version>`
+- `liquibase/liquibase-secure:<version>`
 
 ### Database Connection Variables
 
@@ -111,24 +103,24 @@ The following tags are officially supported and can be found on [Docker Hub](htt
 | `LIQUIBASE_COMMAND_PASSWORD` | Database password | `dbpass` |
 | `LIQUIBASE_COMMAND_CHANGELOG_FILE` | Path to changelog file | `/liquibase/changelog/changelog.xml` |
 
-### Pro-Specific Configuration
+### Liquibase Secure-Specific Configuration
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `LIQUIBASE_PRO_POLICY_CHECKS_ENABLED` | Enable policy checks | `true` |
-| `LIQUIBASE_PRO_QUALITY_CHECKS_ENABLED` | Enable quality checks | `true` |
+| `LIQUIBASE_SECURE_POLICY_CHECKS_ENABLED` | Enable policy checks | `true` |
+| `LIQUIBASE_SECURE_QUALITY_CHECKS_ENABLED` | Enable quality checks | `true` |
 | `LIQUIBASE_REPORTS_ENABLED` | Enable HTML reports | `true` |
 | `LIQUIBASE_REPORTS_PATH` | Reports output directory | `/tmp/reports` |
 
 ## Required License Configuration
 
-Set your Liquibase Pro license key using the `LIQUIBASE_LICENSE_KEY` environment variable:
+Set your Liquibase Secure license key using the `LIQUIBASE_LICENSE_KEY` environment variable:
 
 ```bash
 $ docker run --rm \
     -e LIQUIBASE_LICENSE_KEY="YOUR_LICENSE_KEY_HERE" \
     -v /path/to/changelog:/liquibase/changelog \
-    liquibase/liquibase-pro \
+    liquibase/liquibase-secure \
     --changelog-file=example-changelog.xml \
     --url="jdbc:postgresql://host.docker.internal:5432/testdb" \
     --username=postgres \
@@ -145,7 +137,7 @@ Mount your changelog directory to the `/liquibase/changelog` volume and use the 
 $ docker run --rm \
     -e LIQUIBASE_LICENSE_KEY="YOUR_LICENSE_KEY_HERE" \
     -v "$(pwd)":/liquibase/changelog \
-    liquibase/liquibase-pro \
+    liquibase/liquibase-secure \
     --changelog-file=example-changelog.xml \
     --search-path=/liquibase/changelog/ \
     update
@@ -159,7 +151,7 @@ To use a default configuration file, mount it in your changelog volume and refer
 $ docker run --rm \
     -e LIQUIBASE_LICENSE_KEY="YOUR_LICENSE_KEY_HERE" \
     -v /path/to/changelog:/liquibase/changelog \
-    liquibase/liquibase-pro \
+    liquibase/liquibase-secure \
     --defaults-file=liquibase.properties update
 ```
 
@@ -171,7 +163,7 @@ username=postgres
 password=password
 changelog-file=example-changelog.xml
 search-path=/liquibase/changelog/
-licenseKey=<PASTE LB PRO LICENSE KEY HERE>
+licenseKey=<PASTE LB SECURE LICENSE KEY HERE>
 ```
 
 ## Adding Additional JARs
@@ -183,13 +175,13 @@ $ docker run --rm \
     -e LIQUIBASE_LICENSE_KEY="YOUR_LICENSE_KEY_HERE" \
     -v /path/to/changelog:/liquibase/changelog \
     -v /path/to/lib:/liquibase/lib \
-    liquibase/liquibase-pro update
+    liquibase/liquibase-secure update
 
 ## 📦 Using the Docker Image
 
 ### 🏷️ Standard Image
 
-The `liquibase/liquibase-pro:<version>` image is the standard choice. Use it as a disposable container or a foundational building block for other images.
+The `liquibase/liquibase-secure:<version>` image is the standard choice. Use it as a disposable container or a foundational building block for other images.
 
 For examples of extending the standard image, see the [standard image examples](https://github.com/liquibase/docker/tree/main/examples).
 
@@ -198,7 +190,7 @@ For examples of extending the standard image, see the [standard image examples](
 
 ```bash
 # Build the image
-docker build . -t liquibase-pro-aws
+docker build . -t liquibase-secure-aws
 
 # Run with AWS credentials
 docker run --rm \
@@ -206,7 +198,7 @@ docker run --rm \
   -e AWS_SECRET_ACCESS_KEY="your-secret-key" \
   -e LIQUIBASE_LICENSE_KEY="your-license-key" \
   -v "$(pwd)":/liquibase/changelog \
-  liquibase-pro-aws \
+  liquibase-secure-aws \
   --changelog-file=changelog.xml \
   --search-path=/liquibase/changelog/ \
   update
@@ -220,7 +212,7 @@ For a complete example using Docker Compose with PostgreSQL:
 version: '3.8'
 services:
   liquibase:
-    image: liquibase/liquibase-pro:latest
+    image: liquibase/liquibase-secure:latest
     environment:
       LIQUIBASE_LICENSE_KEY: "${LIQUIBASE_LICENSE_KEY}"
       LIQUIBASE_COMMAND_URL: "jdbc:postgresql://postgres:5432/example"
@@ -245,7 +237,7 @@ services:
 
 ## License
 
-This Docker image contains Liquibase Pro software which requires a valid commercial license for use.
+This Docker image contains Liquibase Secure software which requires a valid commercial license for use.
 
 For licensing questions, please contact [Liquibase Sales](https://www.liquibase.com/contact).
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Please update your Dockerfiles and scripts to pull from the new official image:
 
 We publish this image to multiple registries:
 
-| Registry | OSS Image | Pro Image |
+| Registry | OSS Image | Secure Image |
 |----------|----------------|-----------|
-| **Docker Hub (default)** | `liquibase/liquibase` | `liquibase/liquibase-pro` |
-| **GitHub Container Registry** | `ghcr.io/liquibase/liquibase` | `ghcr.io/liquibase/liquibase-pro` |
-| **Amazon ECR Public** | `public.ecr.aws/liquibase/liquibase` | `public.ecr.aws/liquibase/liquibase-pro` |
+| **Docker Hub (default)** | `liquibase/liquibase` | `liquibase/liquibase-secure` |
+| **GitHub Container Registry** | `ghcr.io/liquibase/liquibase` | `ghcr.io/liquibase/liquibase-secure` |
+| **Amazon ECR Public** | `public.ecr.aws/liquibase/liquibase` | `public.ecr.aws/liquibase/liquibase-secure` |
 
 ## Dockerfile
 
@@ -41,17 +41,17 @@ docker pull ghcr.io/liquibase/liquibase
 docker pull public.ecr.aws/liquibase/liquibase
 ```
 
-### Liquibase Pro Edition
+### Liquibase Secure Edition
 
 ```bash
 # Docker Hub (default)
-docker pull liquibase/liquibase-pro
+docker pull liquibase/liquibase-secure
 
 # GitHub Container Registry
-docker pull ghcr.io/liquibase/liquibase-pro
+docker pull ghcr.io/liquibase/liquibase-secure
 
 # Amazon ECR Public
-docker pull public.ecr.aws/liquibase/liquibase-pro
+docker pull public.ecr.aws/liquibase/liquibase-secure
 ```
 
 ### Pulling the Latest or Specific Version
@@ -70,18 +70,18 @@ docker pull ghcr.io/liquibase/liquibase:4.32.0
 docker pull public.ecr.aws/liquibase/liquibase:4.32.0
 ```
 
-#### Liquibase Pro Edition
+#### Liquibase Secure Edition
 
 ```bash
 # Latest
-docker pull liquibase/liquibase-pro:latest
-docker pull ghcr.io/liquibase/liquibase-pro:latest
-docker pull public.ecr.aws/liquibase/liquibase-pro:latest
+docker pull liquibase/liquibase-secure:latest
+docker pull ghcr.io/liquibase/liquibase-secure:latest
+docker pull public.ecr.aws/liquibase/liquibase-secure:latest
 
 # Specific version (example: 4.32.0)
-docker pull liquibase/liquibase-pro:4.32.0
-docker pull ghcr.io/liquibase/liquibase-pro:4.32.0
-docker pull public.ecr.aws/liquibase/liquibase-pro:4.32.0
+docker pull liquibase/liquibase-secure:4.32.0
+docker pull ghcr.io/liquibase/liquibase-secure:4.32.0
+docker pull public.ecr.aws/liquibase/liquibase-secure:4.32.0
 ```
 
 For any questions or support, please visit our [Liquibase Community Forum](https://forum.liquibase.org/).
@@ -218,7 +218,7 @@ url: jdbc:postgresql://<IP OR HOSTNAME>:5432/<DATABASE>?currentSchema=<SCHEMA NA
 changeLogFile: changelog.xml
 username: <USERNAME>
 password: <PASSWORD>
-liquibaseProLicenseKey=<PASTE LB Pro LICENSE KEY HERE>
+liquibaseSecureLicenseKey=<PASTE LB Secure LICENSE KEY HERE>
 ```
 
 CLI:

--- a/examples/docker-compose/docker-compose.secure.yml
+++ b/examples/docker-compose/docker-compose.secure.yml
@@ -1,0 +1,38 @@
+services:
+  # PostgreSQL database
+  postgres:
+    image: postgres:15-alpine
+    container_name: liquibase_postgres
+    environment:
+      POSTGRES_DB: liquibase_demo
+      POSTGRES_USER: liquibase
+      POSTGRES_PASSWORD: liquibase_password
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U liquibase -d liquibase_demo"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Liquibase Secure service
+  liquibase:
+    image: liquibase/liquibase-secure:latest
+    container_name: liquibase_secure_runner
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ./changelog:/liquibase/changelog
+      - ./liquibase.properties:/liquibase/liquibase.properties
+    environment:
+      LIQUIBASE_COMMAND_URL: jdbc:postgresql://postgres:5432/liquibase_demo
+      LIQUIBASE_COMMAND_USERNAME: liquibase
+      LIQUIBASE_COMMAND_PASSWORD: liquibase_password
+      LIQUIBASE_LICENSE_KEY: ${LIQUIBASE_LICENSE_KEY}  # Set in your environment
+    command: ["--defaults-file=/liquibase/liquibase.properties", "update"]
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
This pull request updates the QA Docker build workflow to replace all references to "Pro" builds with "Secure" builds, reflecting a change in naming and handling for the secure version of Liquibase. Additionally, it updates workflow logic, artifact download steps, and related messaging to align with this new terminology. There are also minor updates to action versions and workflow triggers. The most important changes are grouped below:

**Build Target and Matrix Updates:**

* All build target options, matrix generation logic, and related identifiers in `.github/workflows/build-qa-docker.yml` have been changed from "Pro" to "Secure" (e.g., `Pro Only` → `Secure Only`, `DockerfilePro` → `DockerfileSecure`, `build_type: pro` → `build_type: secure`). [[1]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL21-R26) [[2]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL41-R51)

**Workflow Steps and Artifact Handling:**

* All workflow step names, conditions, and logic that previously referenced "Pro" now reference "Secure" (e.g., AWS credential configuration, artifact download, workflow triggers, and fallback logic). Artifact download steps now fetch and extract the secure build zip from the appropriate S3 location and trigger the correct workflow if the artifact is missing. [[1]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL90-R98) [[2]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL122-R174) [[3]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL260-R258) [[4]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL275-R314)

**Dockerfile Modification Logic:**

* The logic for modifying Dockerfiles now uses `DockerfileSecure` and updates related version and SHA256 argument handling. The awk script that rewrites the Dockerfile for secure builds has been adjusted to match the new naming and download block patterns. [[1]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL360-R353) [[2]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL377-L393) [[3]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL402-R416)

**Action Version Updates:**

* The workflow downgrades some GitHub Actions to previous major versions for stability (e.g., `aws-actions/configure-aws-credentials` from v5 to v4, `actions/checkout` from v5 to v4). [[1]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL77-R77) [[2]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL110-R110)

**Release Workflow Trigger Updates:**

* The release workflow trigger in `.github/workflows/create-release.yml` is updated to listen for `liquibase-secure-release` events instead of `liquibase-pro-release`.