### PR TITLE
Fix/docker creds for readme change

### DIFF
--- a/.github/workflows/publish-liquibase-secure-readme.yml
+++ b/.github/workflows/publish-liquibase-secure-readme.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Update Liquibase Secure README on Docker Hub
         uses: peter-evans/dockerhub-description@v4
         with:
-          username: ${{ env.DOCKERHUB_USERNAME_DECODED }}
-          password: ${{ env.DOCKERHUB_UPDATE_README }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
           repository: liquibase/liquibase-pro
           readme-filepath: ./README-secure.md
           short-description: "Liquibase Secure"

--- a/.github/workflows/publish-oss-readme.yml
+++ b/.github/workflows/publish-oss-readme.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Update Liquibase OSS README on Docker Hub
         uses: peter-evans/dockerhub-description@v4
         with:
-          username: ${{ env.DOCKERHUB_USERNAME_DECODED }}
-          password: ${{ env.DOCKERHUB_UPDATE_README }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
           repository: liquibase/liquibase
           readme-filepath: README.md
           short-description: "Liquibase OSS"


### PR DESCRIPTION
This pull request updates the authentication method for updating Docker Hub READMEs in both the secure and OSS workflows. The workflows now use the standard `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` environment variables instead of the previously decoded username and a different password variable.

Authentication updates for Docker Hub workflows:

* Updated the `publish-liquibase-secure-readme.yml` workflow to use `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` for Docker Hub authentication instead of `DOCKERHUB_USERNAME_DECODED` and `DOCKERHUB_UPDATE_README`.
* Updated the `publish-oss-readme.yml` workflow to use `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` for Docker Hub authentication instead of `DOCKERHUB_USERNAME_DECODED` and `DOCKERHUB_UPDATE_README`.