### PR TITLE
DAT-20870: fix the credentials used for docker readmes

### DIFF
--- a/.github/workflows/publish-liquibase-secure-readme.yml
+++ b/.github/workflows/publish-liquibase-secure-readme.yml
@@ -43,7 +43,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ env.DOCKERHUB_USERNAME_DECODED}}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          password: ${{ env.DOCKERHUB_UPDATE_README }}
           repository: liquibase/liquibase-pro
           readme-filepath: ./README-secure.md
           short-description: "Liquibase Secure"

--- a/.github/workflows/publish-liquibase-secure-readme.yml
+++ b/.github/workflows/publish-liquibase-secure-readme.yml
@@ -43,7 +43,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ env.DOCKERHUB_USERNAME_DECODED}}
-          password: ${{ env.DOCKERHUB_UPDATE_README }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
           repository: liquibase/liquibase-pro
           readme-filepath: ./README-secure.md
           short-description: "Liquibase Secure"

--- a/.github/workflows/publish-liquibase-secure-readme.yml
+++ b/.github/workflows/publish-liquibase-secure-readme.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths:
       - 'README-secure.md'
-      - 'README-pro.md'
     branches:
       - main
   workflow_dispatch:
@@ -43,7 +42,7 @@ jobs:
       - name: Update Liquibase Secure README on Docker Hub
         uses: peter-evans/dockerhub-description@v4
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
+          username: ${{ env.DOCKERHUB_USERNAME_DECODED}}
           password: ${{ env.DOCKERHUB_UPDATE_README }}
           repository: liquibase/liquibase-pro
           readme-filepath: ./README-secure.md

--- a/.github/workflows/publish-liquibase-secure-readme.yml
+++ b/.github/workflows/publish-liquibase-secure-readme.yml
@@ -44,7 +44,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          password: ${{ env.DOCKERHUB_UPDATE_README }}
           repository: liquibase/liquibase-pro
           readme-filepath: ./README-secure.md
           short-description: "Liquibase Secure"

--- a/.github/workflows/publish-oss-readme.yml
+++ b/.github/workflows/publish-oss-readme.yml
@@ -42,7 +42,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ env.DOCKERHUB_USERNAME_DECODED }}
-          password: ${{ env.DOCKERHUB_UPDATE_README }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
           repository: liquibase/liquibase
           readme-filepath: README.md
           short-description: "Liquibase OSS"

--- a/.github/workflows/publish-oss-readme.yml
+++ b/.github/workflows/publish-oss-readme.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Update Liquibase OSS README on Docker Hub
         uses: peter-evans/dockerhub-description@v4
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
+          username: ${{ env.DOCKERHUB_USERNAME_DECODED }}
           password: ${{ env.DOCKERHUB_UPDATE_README }}
           repository: liquibase/liquibase
           readme-filepath: README.md

--- a/.github/workflows/publish-oss-readme.yml
+++ b/.github/workflows/publish-oss-readme.yml
@@ -42,7 +42,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ env.DOCKERHUB_USERNAME_DECODED }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          password: ${{ env.DOCKERHUB_UPDATE_README }}
           repository: liquibase/liquibase
           readme-filepath: README.md
           short-description: "Liquibase OSS"

--- a/.github/workflows/publish-oss-readme.yml
+++ b/.github/workflows/publish-oss-readme.yml
@@ -42,7 +42,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          password: ${{ env.DOCKERHUB_UPDATE_README }}
           repository: liquibase/liquibase
           readme-filepath: README.md
           short-description: "Liquibase OSS"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows responsible for publishing Docker Hub README files for both the Secure and OSS versions of Liquibase. The main changes involve updating environment variable usage for authentication and refining the trigger paths for the secure README workflow.

Authentication updates:

* Both `.github/workflows/publish-liquibase-secure-readme.yml` and `.github/workflows/publish-oss-readme.yml` now use `DOCKERHUB_USERNAME_DECODED` and `DOCKERHUB_UPDATE_README` environment variables for Docker Hub authentication instead of the previous variables (`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`). [[1]](diffhunk://#diff-66c8ed63f6df5211caff5211b12ad4167baf4f88e88db0d468dc718b75b647c1L46-R46) [[2]](diffhunk://#diff-f859117c0e40e66626354f7a158888db5f66ce7ba9cc379aa8ebce2cd19dec59L44-R45)

Workflow trigger refinement:

* The `publish-liquibase-secure-readme.yml` workflow will now only trigger on changes to `README-secure.md` (removing `README-pro.md` from the trigger paths).