### PR TITLE
Fix license and support contact details in README

### DIFF
--- a/README-secure.md
+++ b/README-secure.md
@@ -4,9 +4,9 @@
 
 ## ⚠️ License Requirements
 
-> **WARNING**: Liquibase Secure requires a valid license key to use Secure features. Without a license, the container will run in Liquibase Community mode with limited functionality.
+> **WARNING**: Liquibase Secure requires a valid license key to use Secure features. Without a license, the container will show an invalid license error.
 >
-> - Contact [Liquibase Sales](https://www.liquibase.com/community/contact) to obtain a Liquibase Secure license
+> - Contact [Liquibase Sales](https://www.liquibase.com/contact-us) to obtain a Liquibase Secure license
 > - Existing customers receive their Secure license keys in an email.
 
 ## 📋 Secure Features
@@ -17,8 +17,7 @@ Liquibase Secure includes all Community features plus:
 
 ### 🔐 Security & Governance
 
-- **Policy Checks**: Enforce database standards and best practices
-- **Quality Checks**: Advanced validation rules for changesets  
+- **Policy Checks**: Enforce database standards and best practices and advanced validation rules for changesets
 - **Rollback SQL**: Generate rollback scripts for any deployment
 - **Targeted Rollback**: Rollback specific changesets without affecting others
 - **Advanced Database Support**: Enhanced support for Oracle, SQL Server, and other enterprise databases
@@ -80,13 +79,13 @@ docker pull liquibase/liquibase-secure:latest
 docker pull ghcr.io/liquibase/liquibase-secure:latest
 docker pull public.ecr.aws/liquibase/liquibase-secure:latest
 
-# Specific version (example: 4.32.0)
-docker pull liquibase/liquibase-secure:4.32.0
-docker pull ghcr.io/liquibase/liquibase-secure:4.32.0
-docker pull public.ecr.aws/liquibase/liquibase-secure:4.32.0
+# Specific version (example: 5.0.0)
+docker pull liquibase/liquibase-secure:5.0.0
+docker pull ghcr.io/liquibase/liquibase-secure:5.0.0
+docker pull public.ecr.aws/liquibase/liquibase-secure:5.0.0
 ```
 
-For any questions or support, please visit our [Liquibase Community Forum](https://forum.liquibase.org/).
+For any questions or support, please visit our [Liquibase Support](https://forum.liquibase.org/).
 
 ## 🏷️ Supported Tags
 
@@ -239,7 +238,7 @@ services:
 
 This Docker image contains Liquibase Secure software which requires a valid commercial license for use.
 
-For licensing questions, please contact [Liquibase Sales](https://www.liquibase.com/contact).
+For licensing questions, please contact [Liquibase Sales](https://www.liquibase.com/contact-us).
 
 View [license information](https://www.liquibase.com/eula) for the software contained in this image.
 


### PR DESCRIPTION
This pull request makes several updates to the `README-secure.md` file to clarify licensing requirements, update contact and support links, and reflect new versioning for Docker images. The most important changes are summarized below:

**Licensing and Contact Information Updates:**

* Clarified that without a valid license, the container will show an invalid license error, and updated the contact link for obtaining a Liquibase Secure license.
* Updated the contact link for licensing questions to the new URL.

**Feature Description Improvements:**

* Improved the description of "Policy Checks" to include advanced validation rules for changesets, consolidating the previous "Quality Checks" item.

**Docker Usage and Support Updates:**

* Updated Docker pull instructions to reference version `5.0.0` instead of `4.32.0`, and changed the support link to "Liquibase Support."