### PR TITLE
Fix OpenShift compatibility by allowing arbitrary user IDs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM eclipse-temurin:21-jre-jammy
 # Create liquibase user
 RUN groupadd --gid 1001 liquibase && \
     useradd --uid 1001 --gid liquibase --create-home --home-dir /liquibase liquibase && \
-    chown liquibase /liquibase
+    chown liquibase:root /liquibase && \
+    chmod g+rx /liquibase
 
 # Download and install Liquibase
 WORKDIR /liquibase

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -4,7 +4,8 @@ FROM alpine:3.22
 # Create liquibase user
 RUN addgroup --gid 1001 liquibase && \
     adduser --disabled-password --uid 1001 --ingroup liquibase --home /liquibase liquibase && \
-    chown liquibase /liquibase
+    chown liquibase:root /liquibase && \
+    chmod g+rx /liquibase
 
 # Install smaller JRE, if available and acceptable
 RUN apk add --no-cache openjdk21-jre-headless bash

--- a/DockerfileSecure
+++ b/DockerfileSecure
@@ -4,7 +4,8 @@ FROM eclipse-temurin:21-jre-jammy
 # Create liquibase user
 RUN groupadd --gid 1001 liquibase && \
     useradd --uid 1001 --gid liquibase --create-home --home-dir /liquibase liquibase && \
-    chown liquibase /liquibase
+    chown liquibase:root /liquibase && \
+    chmod g+rx /liquibase
 
 # Download and install Liquibase
 WORKDIR /liquibase


### PR DESCRIPTION
## Summary

Fixes #367 - Restores the ability to run Liquibase containers with arbitrary user IDs in OpenShift and similar Kubernetes platforms.

## Problem

Since version 4.31.0, the Liquibase Docker images fail to run in OpenShift because:
- OpenShift runs containers with random user IDs for security
- The `/liquibase` directory was owned by `liquibase:liquibase` (UID:GID 1001:1001)
- Random UIDs couldn't access the directory, causing container startup failures

## Solution

Changed the directory ownership and permissions to follow OpenShift best practices:
- Changed ownership from `liquibase:liquibase` to `liquibase:root`
- Added group read/execute permissions with `chmod g+rx /liquibase`

This allows any user ID to access the directory as long as they're in the root group (GID 0), which is standard in OpenShift/Kubernetes environments.

## Changes

Updated all three Dockerfile variants:
- `Dockerfile` (standard image)
- `Dockerfile.alpine` (Alpine-based image)
- `DockerfileSecure` (Liquibase Secure image)

## Testing

This follows the same pattern recommended in the issue comments and aligns with [OpenShift's guidelines for creating images](https://docs.openshift.com/container-platform/latest/openshift_images/create-images.html#images-create-guide-openshift_create-images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)