### PR TITLE
DAT-20978: Update Docker container license labels for Liquibase 5.0

### DIFF
--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -538,7 +538,8 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/liquibase/docker
             org.opencontainers.image.description=Liquibase QA Container Image${{ matrix.suffix }}
-            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.licenses=${{ matrix.build_type == 'secure' && 'LicenseRef-Liquibase-EULA' || 'FSL-1.1-ALv2' }}
+            ${{ matrix.build_type == 'secure' && 'org.opencontainers.image.licenses.url=https://www.liquibase.com/eula' || '' }}
             org.opencontainers.image.vendor=Liquibase
             org.opencontainers.image.version=${{ matrix.is_rc == true && inputs.secure-version || inputs.liquibaseBranch }}
             org.opencontainers.image.documentation=https://docs.liquibase.com

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -438,7 +438,8 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/liquibase/docker
             org.opencontainers.image.description=${{ matrix.type == 'liquibase-secure-release' && 'Liquibase Secure Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
-            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.licenses=${{ matrix.type == 'liquibase-secure-release' && 'LicenseRef-Liquibase-EULA' || 'FSL-1.1-ALv2' }}
+            ${{ matrix.type == 'liquibase-secure-release' && 'org.opencontainers.image.licenses.url=https://www.liquibase.com/eula' || '' }}
             org.opencontainers.image.vendor=Liquibase
             org.opencontainers.image.version=${{ needs.update-dockerfiles.outputs.extensionVersion }}
             org.opencontainers.image.documentation=https://docs.liquibase.com
@@ -446,7 +447,8 @@ jobs:
           annotations: |
             org.opencontainers.image.source=https://github.com/liquibase/docker
             org.opencontainers.image.description=${{ matrix.type == 'liquibase-secure-release' && 'Liquibase Secure Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
-            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.licenses=${{ matrix.type == 'liquibase-secure-release' && 'LicenseRef-Liquibase-EULA' || 'FSL-1.1-ALv2' }}
+            ${{ matrix.type == 'liquibase-secure-release' && 'org.opencontainers.image.licenses.url=https://www.liquibase.com/eula' || '' }}
             org.opencontainers.image.vendor=Liquibase
             org.opencontainers.image.version=${{ needs.update-dockerfiles.outputs.extensionVersion }}
             org.opencontainers.image.documentation=https://docs.liquibase.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ARG LPM_SHA256_ARM=541a220aa3c3227cc0fb40b15976b11011568a06a6499af090258bf604f45
     
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Container Image"
-LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.licenses="FSL-1.1-ALv2"
 LABEL org.opencontainers.image.vendor="Liquibase"
 LABEL org.opencontainers.image.version="${LIQUIBASE_VERSION}"
 LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -32,7 +32,7 @@ ARG LPM_SHA256_ARM=541a220aa3c3227cc0fb40b15976b11011568a06a6499af090258bf604f45
 
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Container Image (Alpine)"
-LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.licenses="FSL-1.1-ALv2"
 LABEL org.opencontainers.image.vendor="Liquibase"
 LABEL org.opencontainers.image.version="${LIQUIBASE_VERSION}"
 LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"

--- a/DockerfileSecure
+++ b/DockerfileSecure
@@ -14,7 +14,8 @@ ARG LB_SECURE_SHA256=47c96bcfc1efb06d1906faeca308a609a99013bf2349ccb61e287edfb8d
 
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Secure Container Image"
-LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.licenses="LicenseRef-Liquibase-EULA"
+LABEL org.opencontainers.image.licenses.url="https://www.liquibase.com/eula"
 LABEL org.opencontainers.image.vendor="Liquibase"
 LABEL org.opencontainers.image.version="${LIQUIBASE_SECURE_VERSION}"
 LABEL org.opencontainers.image.documentation="https://docs.liquibase.com"


### PR DESCRIPTION
## Summary

Updates OCI image license labels in Docker containers to reflect Liquibase 5.0's new licensing model:
- **Liquibase OSS**: Changed from `Apache-2.0` to `FSL-1.1-ALv2` (Functional Source License)
- **Liquibase Secure**: Changed from `Apache-2.0` to `LicenseRef-Liquibase-EULA` with EULA URL

## Changes

### Dockerfiles
- ✅ `Dockerfile`: Updated license label to `FSL-1.1-ALv2`
- ✅ `Dockerfile.alpine`: Updated license label to `FSL-1.1-ALv2`
- ✅ `DockerfileSecure`: Updated license label to `LicenseRef-Liquibase-EULA` and added `org.opencontainers.image.licenses.url="https://www.liquibase.com/eula"`

### GitHub Actions Workflows
- ✅ `.github/workflows/create-release.yml`: Added conditional license labels based on `matrix.type` (OSS vs Secure)
- ✅ `.github/workflows/build-qa-docker.yml`: Added conditional license labels based on `matrix.build_type` (OSS vs Secure)

## Technical Details

- Uses SPDX-compliant license identifiers per [OCI Image Specification](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
- `FSL-1.1-ALv2` is the official SPDX identifier for Functional Source License 1.1 with Apache License v2 future license
- `LicenseRef-Liquibase-EULA` follows SPDX custom license reference format for proprietary licenses
- Dynamic label selection ensures correct licensing for each image variant

## Testing

After merge, verify labels in published images:

```bash
# Test OSS image
docker pull liquibase/liquibase:latest
docker inspect liquibase/liquibase:latest | jq '.[0].Config.Labels."org.opencontainers.image.licenses"'
# Expected: "FSL-1.1-ALv2"

# Test Secure image
docker pull liquibase/liquibase-secure:latest
docker inspect liquibase/liquibase-secure:latest | jq '.[0].Config.Labels."org.opencontainers.image.licenses"'
# Expected: "LicenseRef-Liquibase-EULA"

docker inspect liquibase/liquibase-secure:latest | jq '.[0].Config.Labels."org.opencontainers.image.licenses.url"'
# Expected: "https://www.liquibase.com/eula"
```

## Related

- **Jira**: [DAT-20978](https://datical.atlassian.net/browse/DAT-20978)
- **Epic**: [DAT-20865](https://datical.atlassian.net/browse/DAT-20865) - 5.0 Release Issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-20978]: https://datical.atlassian.net/browse/DAT-20978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ