### PR TITLE
DAT-20800 Separate Release and Non-Release Liquibase Pro Builds in S3 with Automated Cleanup

### DIFF
--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -171,7 +171,7 @@ jobs:
                 BASE_VERSION="${BASH_REMATCH[1]}"
                 RC_NUMBER="${BASH_REMATCH[2]}"
                 LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.tar.gz"
-                S3_URL="s3://repo.liquibase.com/releases/rc/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
+                S3_URL="s3://repo.liquibase.com/non-releases/secure/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
                 echo "Using RC S3 path: $S3_URL"
               else
                 # Regular production version
@@ -330,7 +330,7 @@ jobs:
               BASE_VERSION="${BASH_REMATCH[1]}"
               RC_NUMBER="${BASH_REMATCH[2]}"
               LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.tar.gz"
-              S3_URL="s3://repo.liquibase.com/releases/rc/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
+              S3_URL="s3://repo.liquibase.com/non-releases/secure/${VERSION}/${LIQUIBASE_SECURE_ZIP}"
             else
               LIQUIBASE_SECURE_ZIP="liquibase-secure-${VERSION}.zip"
               S3_URL="s3://repo.liquibase.com/releases/secure/${VERSION}/${LIQUIBASE_SECURE_ZIP}"


### PR DESCRIPTION
This pull request updates the S3 path used for release candidate (RC) builds in the `.github/workflows/build-qa-docker.yml` workflow. The change ensures that RC artifacts are now uploaded to a different S3 location, improving the separation between release and non-release artifacts.

**Workflow configuration changes:**

* Updated the S3 path for RC builds from `s3://repo.liquibase.com/releases/rc/` to `s3://repo.liquibase.com/non-releases/secure/` in two places within the build workflow (`.github/workflows/build-qa-docker.yml`). [[1]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL174-R174) [[2]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL333-R333)