### PR TITLE
chore: Update base images to Ubuntu Noble 24.04 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder Stage
-FROM eclipse-temurin:21-jre-jammy
+FROM eclipse-temurin:21-jre-noble
 
 # Create liquibase user
 RUN groupadd --gid 1001 liquibase && \

--- a/DockerfileSecure
+++ b/DockerfileSecure
@@ -1,5 +1,5 @@
 # Builder Stage
-FROM eclipse-temurin:21-jre-jammy
+FROM eclipse-temurin:21-jre-noble
 
 # Create liquibase user
 RUN groupadd --gid 1001 liquibase && \


### PR DESCRIPTION
## Summary
- Updates eclipse-temurin base images from Ubuntu 22.04 (Jammy) to 24.04 LTS (Noble)
- Applies to both standard and secure Dockerfiles
- No Java version change (stays on Java 21 LTS)

## Changes
- `Dockerfile`: `eclipse-temurin:21-jre-jammy` → `eclipse-temurin:21-jre-noble`
- `DockerfileSecure`: `eclipse-temurin:21-jre-jammy` → `eclipse-temurin:21-jre-noble`
- `Dockerfile.alpine`: No changes (already on latest Alpine 3.22)

## Benefits
✅ Extended Ubuntu LTS support until **2029** (vs 2027 for Jammy)  
✅ Newer security patches and package versions  
✅ Same Java 21 LTS runtime (no breaking changes)  
✅ Lower risk: LTS → LTS upgrade, well-tested base image  

## Testing
- [ ] Local build verification of all 3 Dockerfiles
- [ ] Automated test suite passes (`.github/workflows/test.yml`)
- [ ] Trivy security scan comparison (Noble vs Jammy)
- [ ] Verify no regression in functionality

## Risk Assessment
**Low Risk** - Conservative LTS-to-LTS upgrade with same runtime version

🤖 Generated with [Claude Code](https://claude.com/claude-code)