### PR TITLE
Dat 20987 small fix

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -174,14 +174,14 @@ jobs:
               sed -i 's/^ARG LB_SECURE_SHA256=.*/ARG LB_SECURE_SHA256='"$LIQUIBASE_SECURE_SHA"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LPM_SHA256=.*/ARG LPM_SHA256='"$LPM_SHA"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
-              #git add "${file}"
+              git add "${file}"
             done
             if git diff-index --cached --quiet HEAD --; then
               echo "Nothing new to commit"
               echo "changes_made=false" >> $GITHUB_OUTPUT
             else
               COMMIT_MSG="Liquibase Secure Version Bumped to ${{ steps.collect-data.outputs.liquibaseVersion }}"
-              #git commit -m "${COMMIT_MSG}"
+              git commit -m "${COMMIT_MSG}"
               echo "changes_made=true" >> $GITHUB_OUTPUT
             fi
           else
@@ -194,14 +194,14 @@ jobs:
               sed -i 's/^ARG LB_SHA256=.*/ARG LB_SHA256='"$LIQUIBASE_SHA"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LPM_SHA256=.*/ARG LPM_SHA256='"$LPM_SHA"'/' "${{ github.workspace }}/${file}"
               sed -i 's/^ARG LPM_SHA256_ARM=.*/ARG LPM_SHA256_ARM='"$LPM_SHA_ARM"'/' "${{ github.workspace }}/${file}"
-              #git add "${file}"
+              git add "${file}"
             done
             if git diff-index --cached --quiet HEAD --; then
               echo "Nothing new to commit"
               echo "changes_made=false" >> $GITHUB_OUTPUT
             else
               COMMIT_MSG="Liquibase Version Bumped to ${{ steps.collect-data.outputs.extensionVersion }}"
-              #git commit -m "${COMMIT_MSG}"
+              git commit -m "${COMMIT_MSG}"
               echo "changes_made=true" >> $GITHUB_OUTPUT
             fi
           fi
@@ -441,124 +441,124 @@ jobs:
             echo "Generated tags: ${TAGS}"
           fi
 
-      # Unified build and push step using generated tags
-      # - name: Build and Push Docker Image
-      #   if: ${{ needs.update-dockerfiles.outputs.releaseType == matrix.type }}
-      #   uses: docker/build-push-action@v6
-      #   with:
-      #     context: .
-      #     file: ${{ matrix.dockerfile }}
-      #     no-cache: true
-      #     push: true
-      #     platforms: linux/amd64,linux/arm64
-      #     tags: ${{ steps.generate-tags.outputs.tags }}
-      #     # Labels applied to each architecture-specific image
-      #     labels: |
-      #       org.opencontainers.image.source=https://github.com/liquibase/docker
-      #       org.opencontainers.image.description=${{ matrix.type == 'liquibase-secure-release' && 'Liquibase Secure Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
-      #       org.opencontainers.image.licenses=${{ matrix.type == 'liquibase-secure-release' && 'LicenseRef-Liquibase-EULA' || 'FSL-1.1-ALv2' }}
-      #       ${{ matrix.type == 'liquibase-secure-release' && 'org.opencontainers.image.licenses.url=https://www.liquibase.com/eula' || '' }}
-      #       org.opencontainers.image.vendor=Liquibase
-      #       org.opencontainers.image.version=${{ needs.update-dockerfiles.outputs.extensionVersion }}
-      #       org.opencontainers.image.documentation=https://docs.liquibase.com
-      #     # Annotations applied to the manifest list (important for multi-arch images)
-      #     annotations: |
-      #       org.opencontainers.image.source=https://github.com/liquibase/docker
-      #       org.opencontainers.image.description=${{ matrix.type == 'liquibase-secure-release' && 'Liquibase Secure Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
-      #       org.opencontainers.image.licenses=${{ matrix.type == 'liquibase-secure-release' && 'LicenseRef-Liquibase-EULA' || 'FSL-1.1-ALv2' }}
-      #       ${{ matrix.type == 'liquibase-secure-release' && 'org.opencontainers.image.licenses.url=https://www.liquibase.com/eula' || '' }}
-      #       org.opencontainers.image.vendor=Liquibase
-      #       org.opencontainers.image.version=${{ needs.update-dockerfiles.outputs.extensionVersion }}
-      #       org.opencontainers.image.documentation=https://docs.liquibase.com
+      #Unified build and push step using generated tags
+      - name: Build and Push Docker Image
+        if: ${{ needs.update-dockerfiles.outputs.releaseType == matrix.type }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          no-cache: true
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.generate-tags.outputs.tags }}
+          # Labels applied to each architecture-specific image
+          labels: |
+            org.opencontainers.image.source=https://github.com/liquibase/docker
+            org.opencontainers.image.description=${{ matrix.type == 'liquibase-secure-release' && 'Liquibase Secure Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
+            org.opencontainers.image.licenses=${{ matrix.type == 'liquibase-secure-release' && 'LicenseRef-Liquibase-EULA' || 'FSL-1.1-ALv2' }}
+            ${{ matrix.type == 'liquibase-secure-release' && 'org.opencontainers.image.licenses.url=https://www.liquibase.com/eula' || '' }}
+            org.opencontainers.image.vendor=Liquibase
+            org.opencontainers.image.version=${{ needs.update-dockerfiles.outputs.extensionVersion }}
+            org.opencontainers.image.documentation=https://docs.liquibase.com
+          # Annotations applied to the manifest list (important for multi-arch images)
+          annotations: |
+            org.opencontainers.image.source=https://github.com/liquibase/docker
+            org.opencontainers.image.description=${{ matrix.type == 'liquibase-secure-release' && 'Liquibase Secure Container Image' || format('Liquibase Container Image{0}', matrix.suffix == '-alpine' && ' (Alpine)' || '') }}
+            org.opencontainers.image.licenses=${{ matrix.type == 'liquibase-secure-release' && 'LicenseRef-Liquibase-EULA' || 'FSL-1.1-ALv2' }}
+            ${{ matrix.type == 'liquibase-secure-release' && 'org.opencontainers.image.licenses.url=https://www.liquibase.com/eula' || '' }}
+            org.opencontainers.image.vendor=Liquibase
+            org.opencontainers.image.version=${{ needs.update-dockerfiles.outputs.extensionVersion }}
+            org.opencontainers.image.documentation=https://docs.liquibase.com
 
-  # update-official-repo:
-  #   name: "Update Official Docker Repo"
-  #   needs: update-dockerfiles
-  #   if: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && needs.update-dockerfiles.outputs.dryRun == 'false' }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Extract major.minor version
-  #       id: extract_version
-  #       run: |
-  #         VERSION="${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
-  #         echo "MAJOR_MINOR=${VERSION%.*}" >> $GITHUB_ENV
-  #         echo "VERSION: $VERSION"
-  #         echo "MAJOR_MINOR: ${VERSION%.*}"
+  update-official-repo:
+    name: "Update Official Docker Repo"
+    needs: update-dockerfiles
+    if: ${{ needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && needs.update-dockerfiles.outputs.dryRun == 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract major.minor version
+        id: extract_version
+        run: |
+          VERSION="${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
+          echo "MAJOR_MINOR=${VERSION%.*}" >> $GITHUB_ENV
+          echo "VERSION: $VERSION"
+          echo "MAJOR_MINOR: ${VERSION%.*}"
 
-  #     - name: Configure AWS credentials for vault access
-  #       uses: aws-actions/configure-aws-credentials@v5
-  #       with:
-  #         role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
-  #         aws-region: us-east-1
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
 
-  #     - name: Get secrets from vault
-  #       id: vault-secrets
-  #       uses: aws-actions/aws-secretsmanager-get-secrets@v2
-  #       with:
-  #         secret-ids: |
-  #           ,/vault/liquibase
-  #         parse-json-secrets: true
+      - name: Get secrets from vault
+        id: vault-secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
 
-  #     - name: Get GitHub App token
-  #       id: get-token
-  #       uses: actions/create-github-app-token@v2
-  #       with:
-  #         app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
-  #         private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-  #         owner: ${{ github.repository_owner }}
-  #         permission-contents: write
-  #         permission-actions: write
-  #         permission-pull-requests: write
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+          permission-actions: write
+          permission-pull-requests: write
 
-  #     - name: Check out liquibase/official-images
-  #       uses: actions/checkout@v5
-  #       with:
-  #         repository: liquibase/official-images
-  #         ref: master
-  #         token: ${{ steps.get-token.outputs.token }}
+      - name: Check out liquibase/official-images
+        uses: actions/checkout@v5
+        with:
+          repository: liquibase/official-images
+          ref: master
+          token: ${{ steps.get-token.outputs.token }}
 
-  #     - name: Update library/liquibase in liquibase/official-images
-  #       run: |
-  #         echo "Maintainers: Jake Newton <docker@liquibase.com> (@jnewton03)" > library/liquibase
-  #         echo "Architectures: arm64v8, amd64" >> library/liquibase
-  #         echo "GitRepo: https://github.com/liquibase/docker.git" >> library/liquibase
-  #         echo "" >> library/liquibase
-  #         echo "Tags: ${{ env.MAJOR_MINOR }}, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}, latest" >> library/liquibase
-  #         echo "GitFetch: refs/heads/main" >> library/liquibase
-  #         echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
-  #         echo "File: Dockerfile" >> library/liquibase
-  #         echo "" >> library/liquibase
-  #         echo "Tags: ${{ env.MAJOR_MINOR }}-alpine, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}-alpine, alpine" >> library/liquibase
-  #         echo "GitFetch: refs/heads/main" >> library/liquibase
-  #         echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
-  #         echo "File: Dockerfile.alpine" >> library/liquibase
-  #         git add library/liquibase
-  #         if git diff-index --cached --quiet HEAD --
-  #           then
-  #             echo "Nothing new to commit"
-  #           else
-  #             git config user.name "liquibot"
-  #             git config user.email "liquibot@liquibase.org"
-  #             git commit -m "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
-  #             git push
-  #         fi
+      - name: Update library/liquibase in liquibase/official-images
+        run: |
+          echo "Maintainers: Jake Newton <docker@liquibase.com> (@jnewton03)" > library/liquibase
+          echo "Architectures: arm64v8, amd64" >> library/liquibase
+          echo "GitRepo: https://github.com/liquibase/docker.git" >> library/liquibase
+          echo "" >> library/liquibase
+          echo "Tags: ${{ env.MAJOR_MINOR }}, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}, latest" >> library/liquibase
+          echo "GitFetch: refs/heads/main" >> library/liquibase
+          echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
+          echo "File: Dockerfile" >> library/liquibase
+          echo "" >> library/liquibase
+          echo "Tags: ${{ env.MAJOR_MINOR }}-alpine, ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}-alpine, alpine" >> library/liquibase
+          echo "GitFetch: refs/heads/main" >> library/liquibase
+          echo "GitCommit: ${{ needs.update-dockerfiles.outputs.latestCommitSha }}" >> library/liquibase
+          echo "File: Dockerfile.alpine" >> library/liquibase
+          git add library/liquibase
+          if git diff-index --cached --quiet HEAD --
+            then
+              echo "Nothing new to commit"
+            else
+              git config user.name "liquibot"
+              git config user.email "liquibot@liquibase.org"
+              git commit -m "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}"
+              git push
+          fi
 
-  #     - name: Create Official Docker Pull Request
-  #       id: create_pr
-  #       run: |
-  #         response=$(curl \
-  #           -X POST \
-  #           -H "Authorization: token ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}" \
-  #           -H "Accept: application/vnd.github.v3+json" \
-  #           https://api.github.com/repos/docker-library/official-images/pulls \
-  #           -d '{
-  #             "title": "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}",
-  #             "body": "Update library/liquibase with latest commit and version",
-  #             "head": "liquibase:master",
-  #             "base": "master"
-  #           }')
-  #         pr_url=$(echo $response | jq -r '.html_url')
-  #         echo "PR_URL=$pr_url" >> $GITHUB_ENV
+      - name: Create Official Docker Pull Request
+        id: create_pr
+        run: |
+          response=$(curl \
+            -X POST \
+            -H "Authorization: token ${{ env.LIQUIBOT_PAT_GPM_ACCESS }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/docker-library/official-images/pulls \
+            -d '{
+              "title": "Update library/liquibase to ${{ needs.update-dockerfiles.outputs.liquibaseVersion }}",
+              "body": "Update library/liquibase with latest commit and version",
+              "head": "liquibase:master",
+              "base": "master"
+            }')
+          pr_url=$(echo $response | jq -r '.html_url')
+          echo "PR_URL=$pr_url" >> $GITHUB_ENV
 
-  #     - name: Adding Official Docker PR to job summary
-  #       run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY
+      - name: Adding Official Docker PR to job summary
+        run: echo '### 🚀 Official Docker PR -> ${{ env.PR_URL }}' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for creating releases to ensure that releases are only created once per release type, specifically by checking that the `matrix.suffix` is empty. This prevents duplicate releases when multiple Dockerfile variants are present.

Release workflow improvements:

* Updated the condition for the "Determine Release Tag" step to include a check for `matrix.suffix == ''`, ensuring that the release is only created for the base Dockerfile and not for any variant with a suffix. (`.github/workflows/create-release.yml`)
* Updated the condition for the "Create GitHub Release" step to also include the `matrix.suffix == ''` check, further preventing duplicate releases for Dockerfile variants. (`.github/workflows/create-release.yml`)