### PR TITLE
DAT-21115 DevOps :: Update messaging on official Docker liquibase image to include info on 5.0 split

### DIFF
--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -18,12 +18,12 @@ on:
         required: true
         type: choice
         options:
-          - "All (OSS + Alpine + Secure)"
-          - "OSS Only (Standard + Alpine)"
+          - "All (Community + Alpine + Secure)"
+          - "Community Only (Standard + Alpine)"
           - "Secure Only"
-          - "Standard OSS Only"
-          - "Alpine OSS Only"
-        default: "All (OSS + Alpine + Secure)"
+          - "Standard Community Only"
+          - "Alpine Community Only"
+        default: "All (Community + Alpine + Secure)"
       secure-version:
         description: "Secure version to use for 'Secure Only' builds (e.g., 5.0.0-RC10). When set, downloads from S3 instead of building from branch."
         required: false
@@ -49,18 +49,18 @@ jobs:
           fi
 
           case "${{ inputs.buildTargets }}" in
-            "All (OSS + Alpine + Secure)")
-              matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss", "is_rc": false}')
-              matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "oss", "is_rc": false}')
+            "All (Community + Alpine + Secure)")
+              matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "Community", "is_rc": false}')
+              matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "Community", "is_rc": false}')
               if [[ "$IS_RC_BUILD" == "true" ]]; then
                 matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-rc", "suffix": "-secure", "build_type": "secure", "is_rc": true}')
               else
                 matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-qa", "suffix": "-secure", "build_type": "secure", "is_rc": false}')
               fi
               ;;
-            "OSS Only (Standard + Alpine)")
-              matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss", "is_rc": false}')
-              matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "oss", "is_rc": false}')
+            "Community Only (Standard + Alpine)")
+              matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "Community", "is_rc": false}')
+              matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "Community", "is_rc": false}')
               ;;
             "Secure Only")
               if [[ "$IS_RC_BUILD" == "true" ]]; then
@@ -69,11 +69,11 @@ jobs:
                 matrix_items+=('{"dockerfile": "DockerfileSecure", "image_name": "liquibase-secure-qa", "suffix": "-secure", "build_type": "secure", "is_rc": false}')
               fi
               ;;
-            "Standard OSS Only")
-              matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "oss", "is_rc": false}')
+            "Standard Community Only")
+              matrix_items+=('{"dockerfile": "Dockerfile", "image_name": "liquibase-qa", "suffix": "", "build_type": "Community", "is_rc": false}')
               ;;
-            "Alpine OSS Only")
-              matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "oss", "is_rc": false}')
+            "Alpine Community Only")
+              matrix_items+=('{"dockerfile": "Dockerfile.alpine", "image_name": "liquibase-qa-alpine", "suffix": "-alpine", "build_type": "Community", "is_rc": false}')
               ;;
           esac
 
@@ -135,7 +135,7 @@ jobs:
           sudo apt-get install -y jq
 
       - name: Get latest workflow run for branch
-        if: ${{ matrix.build_type == 'oss' }}
+        if: ${{ matrix.build_type == 'Community' }}
         id: get-workflow-run
         run: |
           # Get the latest successful workflow run for the specified branch
@@ -156,7 +156,7 @@ jobs:
             echo "has_workflow_run=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Download liquibase build artifact (OSS) or from S3 (Liquibase-Secure)
+      - name: Download liquibase build artifact (Community) or from S3 (Liquibase-Secure)
         id: download-artifact
         run: |
           if [[ "${{ matrix.build_type }}" == "secure" ]]; then
@@ -229,13 +229,13 @@ jobs:
             fi
 
           else
-            # OSS build handling
+            # Community build handling
             if [[ "${{ steps.get-workflow-run.outputs.has_workflow_run }}" == "false" ]]; then
               echo "No workflow run available, will use fallback build from branch source"
               echo "build_ready=false" >> $GITHUB_OUTPUT
               echo "use_fallback=true" >> $GITHUB_OUTPUT
             else
-              echo "Downloading OSS build from GitHub artifacts..."
+              echo "Downloading Community build from GitHub artifacts..."
 
               # Get artifact download URL
               ARTIFACT_NAME="liquibase-zip-${{ inputs.liquibaseBranch }}"
@@ -367,12 +367,12 @@ jobs:
           echo "use_fallback=false" >> $GITHUB_OUTPUT
 
       - name: Validate and prepare liquibase build
-        if: ${{ (matrix.build_type == 'oss' && (steps.download-artifact.outputs.build_ready == 'true' || steps.download-artifact.outputs.use_fallback == 'true')) || matrix.build_type == 'secure' }}
+        if: ${{ (matrix.build_type == 'Community' && (steps.download-artifact.outputs.build_ready == 'true' || steps.download-artifact.outputs.use_fallback == 'true')) || matrix.build_type == 'secure' }}
         id: validate-build
         run: |
           # Determine build mode
           USE_FALLBACK="false"
-          if [[ "${{ matrix.build_type }}" == "oss" && "${{ steps.download-artifact.outputs.use_fallback }}" == "true" ]]; then
+          if [[ "${{ matrix.build_type }}" == "Community" && "${{ steps.download-artifact.outputs.use_fallback }}" == "true" ]]; then
             USE_FALLBACK="true"
           elif [[ "${{ matrix.build_type }}" == "secure" ]]; then
             # Check for Secure fallback conditions
@@ -593,7 +593,7 @@ jobs:
             fi
           else
             echo "✅ Build Mode: ARTIFACT-BASED (GitHub artifact)"
-            echo "   - OSS build downloaded from GitHub workflow artifacts"
+            echo "   - Community build downloaded from GitHub workflow artifacts"
           fi
 
           echo ""

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -293,8 +293,8 @@ jobs:
           java-version: "8"
           distribution: "adopt"
 
-      # Create GitHub release for OSS (v{version}) or SECURE (v{version}-SECURE)
-      # This ensures OSS and SECURE releases have distinct tags and don't conflict
+      # Create GitHub release for Community (v{version}) or SECURE (v{version}-SECURE)
+      # This ensures Community and SECURE releases have distinct tags and don't conflict
       # Only create the release once per release type (using the base Dockerfile without suffix)
       - name: Determine Release Tag
         id: release-tag

--- a/.github/workflows/publish-oss-readme.yml
+++ b/.github/workflows/publish-oss-readme.yml
@@ -1,20 +1,20 @@
-name: Publish Liquibase OSS README to Docker Hub
+name: Publish Liquibase Community README to Docker Hub
 
 on:
   push:
     paths:
-      - 'README.md'
+      - "README.md"
     branches:
       - main
   workflow_dispatch:
 
 permissions:
   id-token: write
-  
+
 jobs:
-  update-liquibase-oss-readme:
+  update-liquibase-Community-readme:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -38,11 +38,11 @@ jobs:
           decoded_username=$(echo "${{ env.DOCKERHUB_USERNAME }}" | base64 -d)
           echo "DOCKERHUB_USERNAME_DECODED=$decoded_username" >> $GITHUB_ENV
 
-      - name: Update Liquibase OSS README on Docker Hub
+      - name: Update Liquibase Community README on Docker Hub
         uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ env.DOCKERHUB_USERNAME_DECODED }}
           password: ${{ env.DOCKERHUB_UPDATE_README }}
           repository: liquibase/liquibase
           readme-filepath: README.md
-          short-description: "Liquibase OSS"
+          short-description: "Liquibase Community"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is the official Liquibase Docker image repository that builds and publishes Docker images for both Liquibase OSS and Liquibase Secure editions. The repository contains:
+This is the official Liquibase Docker image repository that builds and publishes Docker images for both Liquibase Community and Liquibase Secure editions. The repository contains:
 
-- **Dockerfile**: Standard Liquibase OSS image
+- **Dockerfile**: Standard Liquibase Community image
 - **DockerfileSecure**: Liquibase Secure image (enterprise features)
 - **Dockerfile.alpine**: Alpine Linux variant (lightweight)
 - **Examples**: Database-specific extensions (AWS CLI, SQL Server, PostgreSQL, Oracle)
@@ -15,32 +15,35 @@ This is the official Liquibase Docker image repository that builds and publishes
 ## Image Publishing
 
 Images are published to multiple registries:
-- Docker Hub: `liquibase/liquibase` (OSS) and `liquibase/liquibase-secure` (Secure)
+
+- Docker Hub: `liquibase/liquibase` (Community) and `liquibase/liquibase-secure` (Secure)
 - GitHub Container Registry: `ghcr.io/liquibase/liquibase*`
 - Amazon ECR Public: `public.ecr.aws/liquibase/liquibase*`
 
 ### Release Tagging Strategy
 
-The repository uses distinct tagging strategies for OSS and SECURE releases to prevent conflicts:
+The repository uses distinct tagging strategies for Community and SECURE releases to prevent conflicts:
 
-**OSS Releases** (from `liquibase-release` workflow):
+**Community Releases** (from `liquibase-release` workflow):
+
 - Git tag: `v{version}` (e.g., `v5.0.1`)
 - GitHub Release: `v{version}`
 - Docker images: `liquibase/liquibase:{version}`, `liquibase/liquibase:{major.minor}`, `liquibase/liquibase:latest`
 
 **SECURE Releases** (from `liquibase-secure-release` workflow):
+
 - Git tag: `v{version}-SECURE` (e.g., `v5.0.1-SECURE`)
 - GitHub Release: `v{version}-SECURE`
 - Docker images: `liquibase/liquibase-secure:{version}`, `liquibase/liquibase-secure:{major.minor}`, `liquibase/liquibase-secure:latest`
 
-This ensures that OSS and SECURE releases maintain separate version histories and do not create conflicting tags in Git or GitHub releases.
+This ensures that Community and SECURE releases maintain separate version histories and do not create conflicting tags in Git or GitHub releases.
 
 ## Common Development Commands
 
 ### Building Images
 
 ```bash
-# Build OSS image
+# Build Community image
 docker build -f Dockerfile -t liquibase/liquibase:latest .
 
 # Build Secure image
@@ -53,7 +56,7 @@ docker build -f Dockerfile.alpine -t liquibase/liquibase:latest-alpine .
 ### Testing Images
 
 ```bash
-# Test OSS image
+# Test Community image
 docker run --rm liquibase/liquibase:latest --version
 
 # Test Secure image (requires license)
@@ -80,36 +83,42 @@ docker-compose -f docker-compose.secure.yml up
 ## Architecture
 
 ### Base Image Structure
+
 - **Base**: Eclipse Temurin JRE 21 (Jammy)
 - **User**: Non-root `liquibase` user (UID/GID 1001)
 - **Working Directory**: `/liquibase`
 - **Entrypoint**: `docker-entrypoint.sh` with automatic MySQL driver installation
 
 ### Key Components
-- **Liquibase**: Database migration tool (OSS: GitHub releases, Secure: repo.liquibase.com)
+
+- **Liquibase**: Database migration tool (Community: GitHub releases, Secure: repo.liquibase.com)
 - **LPM**: Liquibase Package Manager for extensions
 - **Default Config**: `liquibase.docker.properties` sets headless mode
 - **CLI-Docker Compatibility**: Auto-detects `/liquibase/changelog` mount and changes working directory for consistent behavior
 
 ### Version Management
-- Liquibase versions are controlled via `LIQUIBASE_VERSION` (OSS) and `LIQUIBASE_PRO_VERSION` (Secure) ARGs
+
+- Liquibase versions are controlled via `LIQUIBASE_VERSION` (Community) and `LIQUIBASE_PRO_VERSION` (Secure) ARGs
 - SHA256 checksums are validated for security
 - LPM version is specified via `LPM_VERSION` ARG
 
 ## Environment Variables
 
 ### Database Connection
+
 - `LIQUIBASE_COMMAND_URL`: JDBC connection string
 - `LIQUIBASE_COMMAND_USERNAME`: Database username
 - `LIQUIBASE_COMMAND_PASSWORD`: Database password
 - `LIQUIBASE_COMMAND_CHANGELOG_FILE`: Path to changelog file
 
 ### Secure Features (DockerfileSecure only)
+
 - `LIQUIBASE_LICENSE_KEY`: Required for Secure features
 - `LIQUIBASE_PRO_POLICY_CHECKS_ENABLED`: Enable policy checks
 - `LIQUIBASE_PRO_QUALITY_CHECKS_ENABLED`: Enable quality checks
 
 ### Special Options
+
 - `INSTALL_MYSQL=true`: Auto-install MySQL driver at runtime
 - `LIQUIBASE_HOME=/liquibase`: Liquibase installation directory
 - `DOCKER_LIQUIBASE=true`: Marker for Docker environment
@@ -118,18 +127,21 @@ docker-compose -f docker-compose.secure.yml up
 ## Extending Images
 
 ### Adding Database Drivers
+
 ```dockerfile
 FROM liquibase/liquibase:latest
 RUN lpm add mysql --global
 ```
 
 ### Using Liquibase Secure
+
 ```dockerfile
 FROM liquibase/liquibase-secure:latest
 ENV LIQUIBASE_LICENSE_KEY=your-license-key
 ```
 
 ### Adding Tools (e.g., AWS CLI)
+
 ```dockerfile
 FROM liquibase/liquibase:latest
 USER root

--- a/README.md
+++ b/README.md
@@ -2,20 +2,21 @@
 
 ## 🚨 Important: Liquibase 5.0 Changes 🚨
 
-### Liquibase OSS vs Liquibase Secure
+### Liquibase Community vs Liquibase Secure
 
 Starting with **Liquibase 5.0**, we have introduced a clear separation between our open source Community edition and our commercial Secure offering:
 
-- **`liquibase/liquibase`** (OSS Edition): Community version under the Functional Source License (FSL)
+- **`liquibase/liquibase`** (Community Edition): Community version under the Functional Source License (FSL)
 - **`liquibase/liquibase-secure`** (Secure Edition): Commercial version with enterprise features
 
 **If you have a valid Liquibase License Key, you should now use `liquibase/liquibase-secure` instead of `liquibase/liquibase`.**
 
 ### 🚨 Breaking Change: Drivers and Extensions No Longer Included
 
-As of **Liquibase 5.0**, the OSS edition (`liquibase/liquibase`) and the official Docker OSS liquibase image **no longer include database drivers or extensions by default**.
+As of **Liquibase 5.0**, the Community edition (`liquibase/liquibase`) and the official Docker Community liquibase image **no longer include database drivers or extensions by default**.
 
 **What this means for you:**
+
 - You must now explicitly add database drivers using the Liquibase Package Manager (LPM)
 - Extensions must be manually installed or mounted into the container
 - MySQL driver installation via `INSTALL_MYSQL=true` environment variable is still supported
@@ -34,9 +35,9 @@ RUN lpm add mssql --global
 
 ---
 
-## 🚨 Notice: New Official Liquibase OSS Docker Image 🚨
+## 🚨 Notice: New Official Liquibase Community Docker Image 🚨
 
-We are excited to announce that a new official Liquibase OSS Docker image is now available at [https://hub.docker.com/_/liquibase](https://hub.docker.com/_/liquibase) starting with liquibase 4.27.0 and newer. We recommend all users to start using this image for the latest updates and support. Any versions prior to 4.27.0 will only be available on the existing `liquibase/liquibase` community image.
+We are excited to announce that a new official Liquibase Community Docker image is now available at [https://hub.docker.com/\_/liquibase](https://hub.docker.com/_/liquibase) starting with liquibase 4.27.0 and newer. We recommend all users to start using this image for the latest updates and support. Any versions prior to 4.27.0 will only be available on the existing `liquibase/liquibase` community image.
 
 ### 🔧 Action Required
 
@@ -46,23 +47,23 @@ Please update your Dockerfiles and scripts to pull from the new official image:
 
 We publish this image to multiple registries:
 
-| Registry | OSS Image | Secure Image |
-|----------|----------------|-----------|
-| **Docker Hub (default)** | `liquibase/liquibase` | `liquibase/liquibase-secure` |
-| **GitHub Container Registry** | `ghcr.io/liquibase/liquibase` | `ghcr.io/liquibase/liquibase-secure` |
-| **Amazon ECR Public** | `public.ecr.aws/liquibase/liquibase` | `public.ecr.aws/liquibase/liquibase-secure` |
+| Registry                      | Community Image                      | Secure Image                                |
+| ----------------------------- | ------------------------------------ | ------------------------------------------- |
+| **Docker Hub (default)**      | `liquibase/liquibase`                | `liquibase/liquibase-secure`                |
+| **GitHub Container Registry** | `ghcr.io/liquibase/liquibase`        | `ghcr.io/liquibase/liquibase-secure`        |
+| **Amazon ECR Public**         | `public.ecr.aws/liquibase/liquibase` | `public.ecr.aws/liquibase/liquibase-secure` |
 
 ## Dockerfile
 
 ```dockerfile
 FROM liquibase:latest
-# OR ghcr.io/liquibase/liquibase:latest    # GHCR  
+# OR ghcr.io/liquibase/liquibase:latest    # GHCR
 # OR public.ecr.aws/liquibase/liquibase:latest   # Amazon ECR Public
 ```
 
 ## Scripts
 
-### OSS Edition
+### Community Edition
 
 ```bash
 # Docker Hub (default)
@@ -90,7 +91,7 @@ docker pull public.ecr.aws/liquibase/liquibase-secure
 
 ### Pulling the Latest or Specific Version
 
-#### OSS Edition
+#### Community Edition
 
 ```bash
 # Latest
@@ -168,10 +169,12 @@ docker run --rm -v /path/to/changelog:/liquibase/changelog liquibase/liquibase -
 Starting with this version, Docker containers now behave consistently with CLI usage for file path handling. When you mount your changelog directory to `/liquibase/changelog`, the container automatically changes its working directory to match, making relative file paths work the same way in both CLI and Docker environments.
 
 **Before this enhancement:**
+
 - CLI: `liquibase generateChangeLog --changelogFile=mychangelog.xml` (creates file in current directory)
 - Docker: `liquibase generateChangeLog --changelogFile=changelog/mychangelog.xml` (had to include path prefix)
 
 **Now (improved):**
+
 - CLI: `liquibase generateChangeLog --changelogFile=mychangelog.xml` (creates file in current directory)
 - Docker: `liquibase generateChangeLog --changelogFile=mychangelog.xml` (creates file in mounted changelog directory)
 
@@ -180,8 +183,9 @@ Both approaches now work identically, making it easier to switch between local C
 #### How it works
 
 When you mount a directory to `/liquibase/changelog`, the container automatically:
+
 1. Detects the presence of the mounted changelog directory
-2. Changes the working directory to `/liquibase/changelog`  
+2. Changes the working directory to `/liquibase/changelog`
 3. Executes Liquibase commands from that location
 
 This ensures that relative paths in your commands work consistently whether you're using CLI locally or Docker containers in CI/CD pipelines.


### PR DESCRIPTION
This pull request updates all references to "OSS" (Open Source Software) in the documentation, workflow files, and Docker image descriptions to "Community," reflecting the new naming convention for the open source edition of Liquibase. The changes ensure consistency across the repository and clarify the distinction between the Community and Secure editions.

**Documentation and Naming Updates:**

* Updated all mentions of "OSS" to "Community" in `README.md` and `CLAUDE.md`, including section headings, usage instructions, registry tables, and image descriptions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R40) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R51) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R66) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L93-R94) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172-R177) [[7]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L7-R9) [[8]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L18-R46) [[9]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L56-R59) [[10]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R86-R121) [[11]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R130-R144)

**Workflow and Automation Updates:**

* Renamed workflow and job identifiers, options, and labels from "OSS" to "Community" in `.github/workflows/build-qa-docker.yml`, `.github/workflows/create-release.yml`, and `.github/workflows/publish-oss-readme.yml` to match the new edition name. [[1]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL21-R26) [[2]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL52-R63) [[3]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL72-R76) [[4]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL138-R138) [[5]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL159-R159) [[6]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL232-R238) [[7]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL370-R375) [[8]](diffhunk://#diff-a7e15b85aea4e8e12c847fa9e3673ea60e5eb31ec445b3a9cb4f4a9e1e2acd3dL596-R596) [[9]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L296-R297) [[10]](diffhunk://#diff-f859117c0e40e66626354f7a158888db5f66ce7ba9cc379aa8ebce2cd19dec59L1-R6) [[11]](diffhunk://#diff-f859117c0e40e66626354f7a158888db5f66ce7ba9cc379aa8ebce2cd19dec59L15-R15) [[12]](diffhunk://#diff-f859117c0e40e66626354f7a158888db5f66ce7ba9cc379aa8ebce2cd19dec59L41-R48)

These changes are primarily editorial and do not affect the underlying logic or functionality of the build, release, or Docker image processes. They ensure that all references to the open source edition are aligned with the new "Community" branding.