### PR TITLE
fix: resolve artifact naming conflict and Slack notification issues in vulnerability scanning workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -38,21 +38,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Build ${{ matrix.image.name }}${{ matrix.image.suffix }} from Dockerfile
-        run: |
-          docker build -f ${{ matrix.image.dockerfile }} -t ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }} .
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
-        with:
-          image-ref: '${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}'
-          vuln-type: 'os,library'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'HIGH,CRITICAL'
-          exit-code: '1'
-          limit-severities-for-sarif: true
-
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@v5
         with:
@@ -67,9 +52,20 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
-      - name: Export vault secrets to environment
+      - name: Build ${{ matrix.image.name }}${{ matrix.image.suffix }} from Dockerfile
         run: |
-          echo "DOCKER_SLACK_WEBHOOK_URL=${{ env.vault_liquibase_DOCKER_SLACK_WEBHOOK_URL }}" >> $GITHUB_ENV
+          docker build -f ${{ matrix.image.dockerfile }} -t ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: '${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}'
+          vuln-type: 'os,library'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+          limit-severities-for-sarif: true
 
       - name: Notify Slack on Build Failure
         if: failure()


### PR DESCRIPTION
## Summary

Fixes two critical issues in the vulnerability scanning workflow that were causing failures and broken notifications.

## Problems Fixed

### 1. Artifact Naming Conflict (409 Errors)

Both `Dockerfile` and `DockerfileSecure` matrix entries used an empty suffix (`suffix: ""`), causing multiple jobs to attempt uploading artifacts with identical names:
- `security-report-trivy`
- `security-report-scout`

This resulted in errors like:
```
##[error]Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

### 2. Slack Webhook Notifications Not Working

**Trivy Job Issue:**
- Vault access happened AFTER the Trivy scan
- When Trivy found CVEs, it exited with code 1, stopping execution
- Vault access steps never ran, leaving `DOCKER_SLACK_WEBHOOK_URL` empty
- Slack notification step failed with: `Secret 'SLACK_WEBHOOK' is missing`

**Redundant Export Step:**
- Lines 70-72 had a manual export step that was incorrect and unnecessary
- The `aws-secretsmanager-get-secrets` action with `parse-json-secrets: true` already creates env vars directly from JSON keys
- With secret-ids prefix `,/vault/liquibase` (empty alias), env vars are created as `DOCKER_SLACK_WEBHOOK_URL` (not `vault_liquibase_DOCKER_SLACK_WEBHOOK_URL`)

## Changes

### Artifact Naming Fix

Updated `.github/workflows/trivy.yml` (lines 33 & 117):
```yaml
# Before
{dockerfile: DockerfileSecure, name: liquibase/liquibase-secure, suffix: ""}

# After
{dockerfile: DockerfileSecure, name: liquibase/liquibase-secure, suffix: "-secure"}
```

**Result:** Artifacts are now uniquely named:
- `security-report-trivy` (Dockerfile)
- `security-report-trivy-alpine` (Dockerfile.alpine)
- `security-report-trivy-secure` (DockerfileSecure) ✨ NEW
- `security-report-scout` (Dockerfile)
- `security-report-scout-alpine` (Dockerfile.alpine)
- `security-report-scout-secure` (DockerfileSecure) ✨ NEW

### Slack Notification Fix

**Trivy Job:**
1. Moved AWS vault access steps (Configure AWS credentials + Get secrets from vault) to BEFORE the Build and Trivy scan steps
2. Removed redundant "Export vault secrets to environment" step (lines 70-72)

**Scout Job:**
- No changes needed - vault access was already in the correct position

**Result:** 
- Vault secrets are retrieved early in both jobs
- `DOCKER_SLACK_WEBHOOK_URL` is available when Slack notification runs with `if: failure()`
- Slack notifications now work correctly for both Trivy and Scout job failures

## Testing

The workflow will automatically run on this PR to verify both fixes work correctly.

## Consistency Note

The `-secure` suffix pattern maintains consistency with the existing `-alpine` suffix used for the Alpine variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)