### PR TITLE
fix: add only-fixed option to Grype scanner

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -141,6 +141,7 @@ jobs:
           sbom: "sbom.spdx.json"
           fail-build: false
           severity-cutoff: high
+          only-fixed: true
           output-format: sarif
         continue-on-error: true
 


### PR DESCRIPTION
## Summary
- Add `only-fixed: true` to the Grype vulnerability scanner configuration
- Only reports CVEs that have available fixes, reducing noise from unfixable vulnerabilities

## Background
The Docker repo's Grype scanner was reporting more vulnerabilities than liquibase secure because it lacked the `only-fixed: true` option. This option filters out vulnerabilities that don't have fixes available yet.

## Test plan
- [ ] Verify the workflow runs successfully
- [ ] Confirm Grype results now only include CVEs with available fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)