### PR TITLE
fix: remove SARIF uploads from published images workflow

### DIFF
--- a/.github/workflows/trivy-scan-published-images.yml
+++ b/.github/workflows/trivy-scan-published-images.yml
@@ -1,6 +1,10 @@
 # Vulnerability scanning for published Docker images using Trivy
 # This workflow scans the published images on Docker Hub for vulnerabilities.
 # It generates a matrix of image/tag combinations and runs Trivy scans on them.
+#
+# NOTE: SARIF results are NOT uploaded to GitHub Security tab to avoid stale alerts.
+# Published image vulnerabilities are tracked via workflow artifacts and GitHub Actions summary.
+# Only the main branch workflow (trivy.yml) populates the Security tab.
 
 name: Published Images Vulnerability Scanning
 
@@ -17,7 +21,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write # Required for uploading SARIF results to GitHub Security tab
   actions: read # Required for private repositories to get Action run status
 
 jobs:
@@ -43,7 +46,6 @@ jobs:
     needs: generate-matrix
     permissions:
       contents: read
-      security-events: write
       actions: read
     strategy:
       fail-fast: false
@@ -135,41 +137,9 @@ jobs:
           path: vulnerability-report-enhanced.md
           retention-days: 90
 
-      - name: Upload Trivy Surface SARIF to GitHub Security tab
-        if: always()
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: "trivy-surface.sarif"
-          category: "trivy-${{ matrix.image }}-${{ matrix.tag }}-surface"
-        continue-on-error: true
-
-      - name: Check if Trivy Deep SARIF exists
-        if: always()
-        id: check_trivy_deep
-        run: |
-          scripts/check-file-exists.sh trivy-deep.sarif exists
-
-      - name: Upload Trivy Deep SARIF to GitHub Security tab
-        if: always() && steps.check_trivy_deep.outputs.exists == 'true'
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: "trivy-deep.sarif"
-          category: "trivy-${{ matrix.image }}-${{ matrix.tag }}-deep"
-        continue-on-error: true
-
-      - name: Check if Grype SARIF exists
-        if: always()
-        id: check_grype
-        run: |
-          scripts/check-file-exists.sh grype-results.sarif exists
-
-      - name: Upload Grype SARIF to GitHub Security tab
-        if: always() && steps.check_grype.outputs.exists == 'true'
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: "grype-results.sarif"
-          category: "trivy-${{ matrix.image }}-${{ matrix.tag }}-grype"
-        continue-on-error: true
+      # NOTE: SARIF uploads to GitHub Security tab removed to prevent stale alerts.
+      # Published image vulnerabilities are tracked via artifacts below.
+      # Only main branch workflow (trivy.yml) populates Security tab.
 
       - name: Set sanitized names for artifacts
         if: always()


### PR DESCRIPTION
## Summary

- Remove SARIF uploads to GitHub Security tab from `trivy-scan-published-images.yml`
- Remove `security-events: write` permission that is no longer needed
- Add documentation explaining the design decision

## Problem

The published images workflow creates version-specific SARIF categories (e.g., `liquibase/liquibase:4.30.0-surface`) that become orphaned when new versions are released. This causes:

1. **Stale alerts**: Resolved vulnerabilities continue showing in the Security tab
2. **Configuration warnings**: 52 "configurations not found" warnings from old version-tagged categories
3. **Confusing security posture**: Mix of current and historical vulnerabilities

## Solution

Only the main branch workflow (`trivy.yml`) should populate the GitHub Security tab. Published image vulnerabilities are tracked via:

- Workflow artifacts (JSON/SARIF files retained for 90 days)
- GitHub Actions summary for each scan
- Enhanced vulnerability reports

This aligns with the "fix forward" approach where we address vulnerabilities in new releases rather than tracking them across all historical versions.

## Related

- Dismissed 41 stale versioned alerts via GitHub API
- Main workflow (`trivy.yml`) continues uploading to Security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)