### PR TITLE
feat: add image and CVE publish dates to vulnerability reports

### DIFF
--- a/.github/workflows/trivy-scan-published-images.yml
+++ b/.github/workflows/trivy-scan-published-images.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Create enhanced vulnerability report with parent JAR mapping
         if: always()
         run: |
-          scripts/create-enhanced-report.sh ${{ matrix.image }} ${{ matrix.tag }}
+          scripts/create-enhanced-report.sh ${{ matrix.image }} ${{ matrix.tag }} "${{ matrix.published }}"
 
       - name: Upload enhanced vulnerability report
         if: always()
@@ -181,7 +181,7 @@ jobs:
       - name: Append summary to GitHub Actions summary
         if: always()
         run: |
-          scripts/append-github-summary.sh ${{ matrix.image }} ${{ matrix.tag }}
+          scripts/append-github-summary.sh ${{ matrix.image }} ${{ matrix.tag }} "${{ matrix.published }}"
 
   notify-results:
     name: Notify Scan Results


### PR DESCRIPTION
## Summary

- Added image publish dates (from Docker Hub `last_updated`) to vulnerability reports
- Added CVE publish dates (from Trivy `PublishedDate`) to vulnerability tables
- Both GitHub Actions summary and artifact reports now include this date information

## Changes

| File | Changes |
|------|---------|
| `scripts/generate-dockerhub-matrix.sh` | Includes `published` field in matrix output |
| `scripts/append-github-summary.sh` | Shows image date in header + CVE dates in tables |
| `scripts/create-enhanced-report.sh` | Same date info in artifact report |
| `.github/workflows/trivy-scan-published-images.yml` | Passes published date to scripts |

## Example Output

**GitHub Actions Summary Header:**
```
## 🛡️ Vulnerability Scan Results for `liquibase/liquibase:5.0.1`

**Image Last Updated**: 2024-01-15
```

**Vulnerability Table (with new CVE Published column):**
```
| Package | Vulnerability | CVE Published | Severity | Installed | Fixed |
|---------|---------------|---------------|----------|-----------|-------|
| openssl | CVE-2024-1234 | 2024-01-10    | HIGH     | 1.1.1     | 1.1.2 |
```

## Test plan

- [ ] Trigger the `Published Images Vulnerability Scanning` workflow manually
- [ ] Verify the GitHub Actions summary shows the image publish date
- [ ] Verify the CVE Published column appears in vulnerability tables
- [ ] Download the `vulnerability-report-*` artifact and verify dates are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)