### PR TITLE
fix: remove repetitive scanner information from GitHub summary

### DIFF
--- a/scripts/append-github-summary.sh
+++ b/scripts/append-github-summary.sh
@@ -158,17 +158,4 @@ if [ "$grype_vulns" -gt 0 ] && [ -f grype-results.json ]; then
   echo "" >> "$GITHUB_STEP_SUMMARY"
 fi
 
-# Add scanner information
-{
-  echo "---"
-  echo ""
-  echo "### 📖 Scanner Information"
-  echo ""
-  echo "- **Trivy Surface**: Scans OS packages and top-level libraries"
-  echo "- **Trivy Deep**: Extracts and scans nested Spring Boot JARs (BOOT-INF/lib) and GraalVM Python packages"
-  echo "- **Grype**: SBOM-based validation for comprehensive dependency analysis"
-  echo ""
-  echo "💡 **Note**: Deep scan detects vulnerabilities in nested dependencies that standard scans miss."
-} >> "$GITHUB_STEP_SUMMARY"
-
 echo "✅ GitHub Actions summary updated"


### PR DESCRIPTION
## Summary
- Removes the "Scanner Information" footer that was being repeated for each image/tag scanned
- The team is familiar with the scanning approach, so this documentation isn't needed

**Before**: Scanner info repeated 10+ times (once per image)
**After**: Clean summary with just the scan results

🤖 Generated with [Claude Code](https://claude.com/claude-code)