### PR TITLE
ci: add path filters to Test Dockerfiles workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,23 @@ name: Test Dockerfiles
 
 on:
   push:
-    branches: ["main", "master"]
-  pull_request:
-    # The branches below must be a subset of the branches above
     branches: ["main"]
+    paths:
+      - 'Dockerfile*'
+      - 'docker-entrypoint.sh'
+      - '.github/workflows/test.yml'
+      - '.github/test/**'
+      - 'examples/**'
+      - 'pom.xml'
+  pull_request:
+    branches: ["main"]
+    paths:
+      - 'Dockerfile*'
+      - 'docker-entrypoint.sh'
+      - '.github/workflows/test.yml'
+      - '.github/test/**'
+      - 'examples/**'
+      - 'pom.xml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Adds path filters to the Test Dockerfiles workflow to prevent unnecessary test runs when changes don't affect Docker images.

### Changes
- Add `paths` filter to `push` and `pull_request` triggers
- Remove `master` from branch list (only `main` exists)

### Paths That Trigger Tests
| Pattern | Description |
|---------|-------------|
| `Dockerfile*` | All Dockerfile variants |
| `docker-entrypoint.sh` | Container entrypoint script |
| `.github/workflows/test.yml` | The test workflow itself |
| `.github/test/**` | Test fixtures |
| `examples/**` | Example Dockerfiles and compose files |
| `pom.xml` | Maven config affecting build |

### Paths That No Longer Trigger Tests
- `scripts/**` - Vulnerability scanning scripts
- `*.md` - Documentation files
- Other workflow files

## Test plan
- [ ] Verify this PR triggers test workflow (since it changes test.yml)
- [ ] Future PRs touching only scripts should NOT trigger test workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)