### PR TITLE
ci: add path filters to Vulnerability Scanning workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -9,9 +9,20 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
+    paths:
+      - 'Dockerfile*'
+      - 'docker-entrypoint.sh'
+      - '.github/workflows/trivy.yml'
+      - 'examples/**'
+      - 'pom.xml'
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: ["main"]
+    paths:
+      - 'Dockerfile*'
+      - 'docker-entrypoint.sh'
+      - '.github/workflows/trivy.yml'
+      - 'examples/**'
+      - 'pom.xml'
   schedule:
     - cron: "0 7 * * 1-5" # Run every weekday at 7am UTC
 


### PR DESCRIPTION
## Summary

Adds path filters to the Vulnerability Scanning workflow to prevent unnecessary scans when changes don't affect Docker images.

### Changes
- Add `paths` filter to `push` and `pull_request` triggers

### Paths That Trigger Scans
| Pattern | Description |
|---------|-------------|
| `Dockerfile*` | All Dockerfile variants |
| `docker-entrypoint.sh` | Container entrypoint script |
| `.github/workflows/trivy.yml` | The workflow itself |
| `examples/**` | Example Dockerfiles and compose files |
| `pom.xml` | Maven config affecting build |

### Paths That No Longer Trigger Scans
- `scripts/**` - Vulnerability reporting scripts
- `*.md` - Documentation files
- Other workflow files

### Unaffected Triggers
- **Scheduled scans** - Still run daily on weekdays
- **workflow_dispatch** - Manual runs always work

## Test plan
- [ ] Verify this PR triggers the workflow (changes trivy.yml)
- [ ] Future PRs touching only scripts should NOT trigger vulnerability scans
- [ ] Scheduled runs should continue working

🤖 Generated with [Claude Code](https://claude.com/claude-code)