### PR TITLE
security: pin third-party GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -94,14 +94,14 @@ jobs:
       matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
     steps:
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets-liquibase
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
             ,/vault/liquibase
@@ -109,7 +109,7 @@ jobs:
 
       - name: Configure AWS credentials for Liquibase-Secure builds
         if: ${{ matrix.build_type == 'secure' }}
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ env.AWS_PROD_GITHUB_OIDC_ROLE_ARN_LIQUIBASE_PRO }}
           aws-region: us-east-1
@@ -307,7 +307,7 @@ jobs:
         if: ${{ matrix.build_type == 'secure' && steps.download-artifact.outputs.trigger_liquibase_secure_workflow == 'true' && steps.download-artifact.outputs.use_fallback != 'true' }}
         id: trigger-liquibase-secure-release
         continue-on-error: true
-        uses: the-actions-org/workflow-dispatch@v4
+        uses: the-actions-org/workflow-dispatch@3133c5d135c7dbe4be4f9793872b6ef331b53bc7 # v4
         with:
           workflow: secure-release-to-s3.yml
           token: ${{ steps.get-token.outputs.token }}
@@ -510,15 +510,15 @@ jobs:
 
       - name: Set up Docker Buildx
         if: ${{ steps.validate-build.outcome == 'success' }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 
       - name: Set up QEMU
         if: ${{ steps.validate-build.outcome == 'success' }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Log in to internal Nexus Docker Registry
         if: ${{ steps.validate-build.outcome == 'success' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
         with:
           registry: ${{ env.REPO_URL }}
           username: ${{ env.REPO_USER }}
@@ -526,7 +526,7 @@ jobs:
 
       - name: Build and push Docker image
         if: ${{ steps.validate-build.outcome == 'success' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -115,14 +115,14 @@ jobs:
           echo "Dry run: ${{ steps.collect-data.outputs.dryRun }}"
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
             ,/vault/liquibase
@@ -259,14 +259,14 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
             ,/vault/liquibase
@@ -303,7 +303,7 @@ jobs:
 
       - name: Create GitHub Release
         if: ${{ needs.update-dockerfiles.outputs.dryRun == 'false' && matrix.suffix == '' && ((needs.update-dockerfiles.outputs.releaseType == 'liquibase-release' && matrix.type == 'liquibase-release') || (needs.update-dockerfiles.outputs.releaseType == 'liquibase-secure-release' && matrix.type == 'liquibase-secure-release')) }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           name: ${{ steps.release-tag.outputs.release_name }}
           tag_name: ${{ steps.release-tag.outputs.tag_name }}
@@ -313,8 +313,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 
       # Define registry configurations based on image type
       - name: Set registry variables
@@ -333,14 +333,14 @@ jobs:
       # Use separate login steps for each registry
       - name: Login to Docker Hub
         if: ${{ env.PUSH_DOCKERHUB == 'true' && needs.update-dockerfiles.outputs.dryRun == 'false' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
         with:
           username: ${{ env.DOCKERHUB_USERNAME_DECODED }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         if: ${{ env.PUSH_GHCR == 'true' && needs.update-dockerfiles.outputs.dryRun == 'false' && steps.set-registries.outputs.GHCR_REPO != '' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -348,14 +348,14 @@ jobs:
 
       - name: Configure AWS credentials for PROD ECR
         id: configure-aws-credentials-prod
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ env.AWS_PROD_GITHUB_OIDC_ROLE_ARN_INFRASTRUCTURE }}
           aws-region: us-east-1
 
       - name: Login to ECR Registry
         if: ${{ env.PUSH_ECR == 'true' && needs.update-dockerfiles.outputs.dryRun == 'false' && steps.set-registries.outputs.ECR_REPO != '' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
         env:
           AWS_REGION: us-east-1
         with:
@@ -366,7 +366,7 @@ jobs:
       # Add login for dry-run mode to private ECR
       - name: Login to Private ECR Registry (dry-run)
         if: ${{ needs.update-dockerfiles.outputs.dryRun == 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
         env:
           AWS_REGION: us-east-1
         with:
@@ -434,7 +434,7 @@ jobs:
       #Unified build and push step using generated tags
       - name: Build and Push Docker Image
         if: ${{ needs.update-dockerfiles.outputs.releaseType == matrix.type }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -476,14 +476,14 @@ jobs:
           echo "MAJOR_MINOR: ${VERSION%.*}"
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
             ,/vault/liquibase

--- a/.github/workflows/publish-liquibase-secure-readme.yml
+++ b/.github/workflows/publish-liquibase-secure-readme.yml
@@ -21,14 +21,14 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
             ,/vault/liquibase

--- a/.github/workflows/publish-oss-readme.yml
+++ b/.github/workflows/publish-oss-readme.yml
@@ -20,14 +20,14 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
             ,/vault/liquibase

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,24 +48,24 @@ jobs:
 
       - name: Setup Docker on macOS
         if: matrix.os == 'macos-15-intel'
-        uses: douglascamata/setup-docker-macos-action@v1.0.2
+        uses: douglascamata/setup-docker-macos-action@5643cfd7e434881308f89f2f3ae8852da11df909 # v1.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 
       - name: Build an image from ${{ matrix.dockerfile }}
         run: |
           docker build -f ${{ matrix.dockerfile }} -t liquibase/liquibase:${{ github.sha }} .
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
             ,/vault/liquibase

--- a/.github/workflows/trivy-scan-published-images.yml
+++ b/.github/workflows/trivy-scan-published-images.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (Surface Scan)
         id: trivy_scan
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: "${{ matrix.image }}:${{ matrix.tag }}"
           vuln-type: "os,library"
@@ -86,7 +86,7 @@ jobs:
 
       - name: Run Trivy scanner on extracted nested JARs (Deep Scan)
         id: trivy_deep
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           scan-type: "rootfs"
           scan-ref: "/tmp/extracted-deps"
@@ -99,7 +99,7 @@ jobs:
 
       - name: Run Grype scanner on SBOM
         id: grype_scan
-        uses: anchore/scan-action@v7
+        uses: anchore/scan-action@40a61b52209e9d50e87917c5b901783d546b12d0 # v7
         with:
           sbom: "sbom.spdx.json"
           fail-build: false

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -59,21 +59,21 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
             ,/vault/liquibase
           parse-json-secrets: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 
       - name: Build ${{ matrix.image.name }}${{ matrix.image.suffix }} from Dockerfile
         run: |
@@ -99,7 +99,7 @@ jobs:
           retention-days: 30
 
       - name: Run Trivy vulnerability scanner (Surface Scan - SARIF)
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: "${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}"
           vuln-type: "os,library"
@@ -110,7 +110,7 @@ jobs:
           limit-severities-for-sarif: true
 
       - name: Run Trivy vulnerability scanner (Surface Scan - JSON)
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: "${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}"
           vuln-type: "os,library"
@@ -121,7 +121,7 @@ jobs:
 
       - name: Run Trivy scanner on extracted nested JARs (Deep Scan - SARIF)
         if: always()
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           scan-type: "rootfs"
           scan-ref: "/tmp/extracted-deps"
@@ -134,7 +134,7 @@ jobs:
 
       - name: Run Trivy scanner on extracted nested JARs (Deep Scan - JSON)
         if: always()
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           scan-type: "rootfs"
           scan-ref: "/tmp/extracted-deps"
@@ -147,7 +147,7 @@ jobs:
       - name: Run Grype scanner on SBOM
         if: always()
         id: grype_scan
-        uses: anchore/scan-action@v7
+        uses: anchore/scan-action@40a61b52209e9d50e87917c5b901783d546b12d0 # v7
         with:
           sbom: "sbom.spdx.json"
           fail-build: false
@@ -180,7 +180,7 @@ jobs:
 
       - name: Notify Slack on Build Failure
         if: failure()
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         env:
           SLACK_COLOR: "failure"
           SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
@@ -220,7 +220,7 @@ jobs:
 
       - name: Generate Security Report
         if: always()
-        uses: rsdmike/github-security-report-action@v3.0.4
+        uses: rsdmike/github-security-report-action@a149b24539044c92786ec39af8ba38c93496495d # v3.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           outputDir: ./reports/trivy${{ matrix.image.dockerfile == 'DockerfileSecure' && '-secure' || matrix.image.suffix }}/
@@ -266,21 +266,21 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
 
       - name: Build ${{ matrix.image.name }}${{ matrix.image.suffix }} from Dockerfile
         run: |
           docker build -f ${{ matrix.image.dockerfile }} -t ${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }} .
 
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
             ,/vault/liquibase
@@ -291,13 +291,13 @@ jobs:
           decoded_username=$(echo "${{ env.DOCKERHUB_USERNAME }}" | base64 -d)
           echo "DOCKERHUB_USERNAME_DECODED=$decoded_username" >> $GITHUB_ENV
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
         with:
           username: ${{ env.DOCKERHUB_USERNAME_DECODED }}
           password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Docker Scout
-        uses: docker/scout-action@v1.18.2
+        uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de # v1.18.2
         with:
           command: cves
           image: "${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}"
@@ -310,7 +310,7 @@ jobs:
 
       - name: Notify Slack on Build Failure
         if: failure()
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         env:
           SLACK_COLOR: "failure"
           SLACK_MESSAGE: "View details on GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}. Triggered by repository: ${{ github.repository }} and job: ${{ github.job }}"
@@ -330,7 +330,7 @@ jobs:
 
       - name: Generate Security Report
         if: always()
-        uses: rsdmike/github-security-report-action@v3.0.4
+        uses: rsdmike/github-security-report-action@a149b24539044c92786ec39af8ba38c93496495d # v3.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           outputDir: ./reports/scout${{ matrix.image.dockerfile == 'DockerfileSecure' && '-secure' || matrix.image.suffix }}/


### PR DESCRIPTION
## Summary

- Pin all third-party GitHub Actions to specific commit SHA hashes to prevent supply-chain attacks
- Addresses all CodeQL "Unpinned tag for a non-immutable Action in workflow" security alerts
- Each action retains a version comment (e.g., `# v3`) for easy maintainability

## Actions Pinned

| Action | Version | Commit SHA |
|--------|---------|------------|
| `anchore/scan-action` | v7 | `40a61b52209e9d50e87917c5b901783d546b12d0` |
| `aquasecurity/trivy-action` | 0.33.1 | `b6643a29fecd7f34b3597bc6acb0a98b03d33ff8` |
| `aws-actions/configure-aws-credentials` | v5 | `61815dcd50bd041e203e49132bacad1fd04d2708` |
| `aws-actions/aws-secretsmanager-get-secrets` | v2 | `a9a7eb4e2f2871d30dc5b892576fde60a2ecc802` |
| `docker/build-push-action` | v6 | `263435318d21b8e681c14492fe198d362a7d2c83` |
| `docker/login-action` | v3 | `5e57cd118135c172c3672efd75eb46360885c0ef` |
| `docker/scout-action` | v1.18.2 | `f8c776824083494ab0d56b8105ba2ca85c86e4de` |
| `docker/setup-buildx-action` | v3 | `e468171a9de216ec08956ac3ada2f0791b6bd435` |
| `docker/setup-qemu-action` | v3 | `c7c53464625b32c7a7e944ae62b3e17d2b600130` |
| `douglascamata/setup-docker-macos-action` | v1.0.2 | `5643cfd7e434881308f89f2f3ae8852da11df909` |
| `rsdmike/github-security-report-action` | v3.0.4 | `a149b24539044c92786ec39af8ba38c93496495d` |
| `rtCamp/action-slack-notify` | v2 | `e31e87e03dd19038e411e38ae27cbad084a90661` |
| `softprops/action-gh-release` | v2 | `a06a81a03ee405af7f2048a818ed3f03bbf83c7b` |
| `the-actions-org/workflow-dispatch` | v4 | `3133c5d135c7dbe4be4f9793872b6ef331b53bc7` |

## Files Changed

- `.github/workflows/trivy.yml`
- `.github/workflows/trivy-scan-published-images.yml`
- `.github/workflows/test.yml`
- `.github/workflows/publish-oss-readme.yml`
- `.github/workflows/publish-liquibase-secure-readme.yml`
- `.github/workflows/build-qa-docker.yml`
- `.github/workflows/create-release.yml`

## Test Plan

- [ ] Verify workflows still execute correctly with pinned actions
- [ ] Confirm CodeQL security alerts are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)