### PR TITLE
DAT-21381: Update build_logic_ref to 'main' in Trivy scan

### DIFF
--- a/.github/workflows/trivy-scan-published-images.yml
+++ b/.github/workflows/trivy-scan-published-images.yml
@@ -55,4 +55,4 @@ jobs:
       fail_on_vulnerabilities: false
       upload_sarif: false
       generate_sbom: true
-      build_logic_ref: DAT-21381
+      build_logic_ref: main


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration by changing the `build_logic_ref` from a specific branch to `main` in the `.github/workflows/trivy-scan-published-images.yml` file.