### PR TITLE
fix: correct ECR login credentials step reference typo

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -399,7 +399,7 @@ jobs:
         with:
           registry: public.ecr.aws
           username: ${{ steps.configure-aws-credentials-prod.outputs.aws_access_key_id }}
-          password: ${{ steps.configure-aws-credentials-prodoutputs.aws_secret_access_key }}
+          password: ${{ steps.configure-aws-credentials-prod.outputs.aws_secret_access_key }}
 
       # Add login for dry-run mode to private ECR
       - name: Login to Private ECR Registry (dry-run)
@@ -410,7 +410,7 @@ jobs:
         with:
           registry: ${{ env.PRIVATE_ECR_DRY_RUN_REPO }}
           username: ${{ steps.configure-aws-credentials-prod.outputs.aws_access_key_id }}
-          password: ${{ steps.configure-aws-credentials-prodoutputs.aws_secret_access_key }}
+          password: ${{ steps.configure-aws-credentials-prod.outputs.aws_secret_access_key }}
 
       # Generate tags dynamically using a separate step
       - name: Generate Docker Tags


### PR DESCRIPTION
## Summary
- Fix typo in `create-release.yml` where `configure-aws-credentials-prodoutputs` was missing a period
- Should be `configure-aws-credentials-prod.outputs` to properly reference the step outputs
- Affects both ECR login and dry-run ECR login steps

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)