### PR TITLE
DAT-21583: Fix Scout VEX filtering and pass secrets to reusable scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -459,6 +459,8 @@ jobs:
           exit-code: true
           only-severities: "critical,high"
           vex-location: ./vex
+          only-vex-affected: true
+          vex-author: "Liquibase Security Team"
 
       - name: Docker Scout JSON output
         if: always()
@@ -468,6 +470,8 @@ jobs:
             --output scout-results.json \
             --only-severities critical,high \
             --vex-location ./vex \
+            --only-vex-affected \
+            --vex-author "Liquibase Security Team" \
             "${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}" || true
 
       - name: Upload Scout JSON results

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -130,6 +130,7 @@ jobs:
       sarif_category: ${{ matrix.image.name }}${{ matrix.image.suffix }}
       generate_sbom: true
       build_logic_ref: main
+    secrets: inherit
 
   # ============================================
   # DISPATCH NEW CVEs FOR INVESTIGATION


### PR DESCRIPTION
## Summary
- Add `secrets: inherit` to the `vulnerability-scan` job so the reusable workflow can access vault secrets for OIDC auth (fixes Trivy diff auth failure)
- Add `--only-vex-affected` and `--vex-author "Liquibase Security Team"` to Docker Scout so VEX-suppressed CVEs are excluded from the exit code
- Without `--only-vex-affected`, Scout shows VEX annotations but still counts suppressed CVEs as failures
- Without `--vex-author`, Scout only accepts VEX from `@docker.com` authors by default

## Test plan
- [ ] Verify Scout excludes netty CVEs (CVE-2026-33870, CVE-2026-33871) from the exit code on the secure image
- [ ] Verify Alpine Trivy scan diff step can authenticate and fetch assessments.yaml
- [ ] Verify community/alpine Scout scans only fail on genuinely unassessed CVEs (CVE-2026-32280)

🤖 Generated with [Claude Code](https://claude.com/claude-code)