### PR TITLE
DAT-22811: Restrict VEX usage to liquibase-secure scans only

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -129,6 +129,7 @@ jobs:
       upload_sarif: true
       sarif_category: ${{ matrix.image.name }}${{ matrix.image.suffix }}
       generate_sbom: true
+      vex_enabled: ${{ matrix.image.name == 'liquibase/liquibase-secure' }}
       build_logic_ref: main
     secrets: inherit
 
@@ -441,6 +442,7 @@ jobs:
           password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Download VEX files for Scout
+        if: matrix.image.name == 'liquibase/liquibase-secure'
         run: |
           mkdir -p ./vex
           curl -sSfL "https://raw.githubusercontent.com/liquibase/vex-repo/main/pkg/maven/org.liquibase/liquibase-core/vex.openvex.json" \
@@ -458,20 +460,22 @@ jobs:
           summary: true
           exit-code: true
           only-severities: "critical,high"
-          vex-location: ./vex
-          only-vex-affected: true
-          vex-author: "Liquibase Security Team"
+          vex-location: ${{ matrix.image.name == 'liquibase/liquibase-secure' && './vex' || '' }}
+          only-vex-affected: ${{ matrix.image.name == 'liquibase/liquibase-secure' }}
+          vex-author: ${{ matrix.image.name == 'liquibase/liquibase-secure' && 'Liquibase Security Team' || '' }}
 
       - name: Docker Scout JSON output
         if: always()
         run: |
-          docker scout cves \
-            --format json \
-            --output scout-results.json \
-            --only-severities critical,high \
-            --vex-location ./vex \
-            --only-vex-affected \
-            --vex-author "Liquibase Security Team" \
+          SCOUT_ARGS=(
+            --format json
+            --output scout-results.json
+            --only-severities critical,high
+          )
+          if [[ "${{ matrix.image.name }}" == "liquibase/liquibase-secure" ]]; then
+            SCOUT_ARGS+=(--vex-location ./vex --only-vex-affected --vex-author "Liquibase Security Team")
+          fi
+          docker scout cves "${SCOUT_ARGS[@]}" \
             "${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}" || true
 
       - name: Upload Scout JSON results

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -449,7 +449,8 @@ jobs:
             -o ./vex/liquibase-core.vex.json
           echo "VEX file downloaded: $(jq '.statements | length' ./vex/liquibase-core.vex.json) statements"
 
-      - name: Docker Scout
+      - name: Docker Scout (with VEX)
+        if: matrix.image.name == 'liquibase/liquibase-secure'
         uses: docker/scout-action@8910519cee8ac046f3ee99686b0dc6654d5ba1a7 # v1.20.3
         with:
           command: cves
@@ -460,9 +461,22 @@ jobs:
           summary: true
           exit-code: true
           only-severities: "critical,high"
-          vex-location: ${{ matrix.image.name == 'liquibase/liquibase-secure' && './vex' || '' }}
-          only-vex-affected: ${{ matrix.image.name == 'liquibase/liquibase-secure' }}
-          vex-author: ${{ matrix.image.name == 'liquibase/liquibase-secure' && 'Liquibase Security Team' || '' }}
+          vex-location: ./vex
+          only-vex-affected: true
+          vex-author: "Liquibase Security Team"
+
+      - name: Docker Scout (without VEX)
+        if: matrix.image.name != 'liquibase/liquibase-secure'
+        uses: docker/scout-action@8910519cee8ac046f3ee99686b0dc6654d5ba1a7 # v1.20.3
+        with:
+          command: cves
+          image: "${{ matrix.image.name }}${{ matrix.image.suffix }}:${{ github.sha }}"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          write-comment: true
+          sarif-file: "scout-results.sarif"
+          summary: true
+          exit-code: true
+          only-severities: "critical,high"
 
       - name: Docker Scout JSON output
         if: always()


### PR DESCRIPTION
## Summary
- VEX is a Liquibase Secure-only feature — stop applying VEX suppression to community and alpine image scans
- VEX files are now only downloaded and applied when scanning `liquibase/liquibase-secure`

## Changes
- **vulnerability-scan job**: Pass `vex_enabled: true` only for `liquibase/liquibase-secure` matrix entry
- **Scout job**: VEX download step conditional on `matrix.image.name == 'liquibase/liquibase-secure'`
- **Scout job**: `--vex-location`, `--only-vex-affected`, `--vex-author` flags conditional on secure image
- **Scout JSON output**: VEX args only added for secure image scans

### Companion PR
- liquibase/build-logic — adds `vex_enabled` input to reusable vulnerability scan workflow

## Test plan
- [ ] Verify `liquibase/liquibase-secure` scans still apply VEX suppression (Trivy + Scout)
- [ ] Verify `liquibase/liquibase` (community) scans show unfiltered results (no VEX)
- [ ] Verify `liquibase/liquibase` (alpine) scans show unfiltered results (no VEX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)