### PR TITLE
fix: grant packages:read + security-events:write to published-images scan

### DIFF
--- a/.github/workflows/trivy-scan-published-images.yml
+++ b/.github/workflows/trivy-scan-published-images.yml
@@ -22,7 +22,9 @@ on:
 permissions:
   contents: read
   actions: read
-  id-token: write # Required for AWS OIDC authentication in reusable vulnerability scan
+  id-token: write       # Required for AWS OIDC authentication in reusable vulnerability scan
+  packages: read        # Required: reusable vulnerability-scan pulls images from GHCR
+  security-events: write # Required: reusable declares this at job level unconditionally
 
 jobs:
   generate-matrix:


### PR DESCRIPTION
## Summary

Fixes the daily `Published Images Vulnerability Scanning` scheduled workflow
failing with `startup_failure` since 2026-04-17.

**Root cause:** On 2026-04-17, `liquibase/build-logic` added `packages: read` and
`security-events: write` to the `vulnerability-scan` job-level permissions in
`reusable-vulnerability-scan.yml`. GitHub's reusable-workflow contract requires
the caller's effective permissions to be a superset of what the called reusable's
jobs declare. The `vulnerability-scan` caller job had no job-level permissions, so
it inherited the workflow-level block, which was missing both scopes. Every
scheduled run has produced this error since then:

```
The nested job 'vulnerability-scan' is requesting 'packages: read, security-events: write',
but is only allowed 'packages: none, security-events: none'.
```

**Fix:** Add both missing permissions at the workflow level in
`.github/workflows/trivy-scan-published-images.yml`, matching the pattern already
used in the sibling `trivy.yml` workflow.

## Failing runs addressed

- https://github.com/liquibase/docker/actions/runs/24661642065 (most recent)
- Also fixes the identical failures on 2026-04-17 and 2026-04-18/19

## Not in scope

- PR #539 (`test.yml` / `trivy.yml` startup failures) — caused by `secrets: inherit`
  misplaced inside `on: workflow_call:` in the `dat-22876-reusables` branch of
  `build-logic`. Already fixed upstream; those runs self-heal on next PR push.

## Test plan

- [ ] Verify this PR's own workflows start cleanly
- [ ] After merge, manually trigger:
  `gh workflow run trivy-scan-published-images.yml --repo liquibase/docker -f max_tags_to_scan=1`
  and confirm jobs start (not `startup_failure` at 1s)
- [ ] Confirm next scheduled run (Mon–Fri 10:00 UTC) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)