### PR TITLE
fix: use autolabeler sub-action for PR labeling (release-drafter v7)

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,11 +12,12 @@ permissions:
 
 jobs:
   # Auto-label PRs based on title (runs on PR events)
+  # Uses the dedicated autolabeler sub-action (required since v7)
   label-prs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v6
+      - uses: release-drafter/release-drafter/autolabeler@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:
           config-name: release-drafter.yml
         env:
@@ -27,7 +28,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v6
+      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:
           config-name: release-drafter.yml
         env:
@@ -38,7 +39,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v6
+      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:
           config-name: release-drafter-secure.yml
         env:


### PR DESCRIPTION
## Summary

Fixes the Release Drafter `label-prs` job failing on every PR since 2026-03-31.

**Root cause:** Dependabot PR #521 bumped release-drafter from v6.3.0 to v7.1.1 but
left the comment as `# v6`, masking the version change. In v7, the main
`release-drafter/release-drafter` action tries to update the draft release on **every**
trigger — including `pull_request` events. When triggered by a PR it sets
`target_commitish` to `refs/pull/N/merge`, which GitHub's release API rejects:

```
Validation Failed: {"resource":"Release","code":"invalid","field":"target_commitish"}
```

**Fix:** Switch the `label-prs` job from the main action to the dedicated autolabeler
sub-action that v7 introduced for PR events:

```
release-drafter/release-drafter/autolabeler@<SHA>  # v7.1.1
```

Also corrects the stale `# v6` comments on all three jobs to `# v7.1.1`.

## What isn't changed

- Same SHA (`139054aa…`) throughout — no version bump, just using the right sub-action
- `draft-community` and `draft-secure` jobs are unchanged in behavior
- Config files (`release-drafter.yml`, `release-drafter-secure.yml`) untouched

## Test plan

- [ ] This PR's own `label-prs` check passes (was failing before)
- [ ] After merge, confirm `draft-community` and `draft-secure` still update the v5.2.0 draft on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)