### PR TITLE
ci: only dispatch CVEs for liquibase-secure images, not community/alpine

### DIFF
--- a/.github/workflows/build-qa-docker.yml
+++ b/.github/workflows/build-qa-docker.yml
@@ -178,6 +178,7 @@ jobs:
       fail_on_vulnerabilities: true
       upload_sarif: false
       generate_sbom: true
+      dispatch_new_cves: false
       build_logic_ref: main
     secrets: inherit
 
@@ -197,6 +198,7 @@ jobs:
       fail_on_vulnerabilities: true
       upload_sarif: false
       generate_sbom: true
+      dispatch_new_cves: false
       build_logic_ref: main
     secrets: inherit
 
@@ -216,6 +218,7 @@ jobs:
       fail_on_vulnerabilities: true
       upload_sarif: false
       generate_sbom: true
+      dispatch_new_cves: true
       build_logic_ref: main
     secrets: inherit
 

--- a/.github/workflows/trivy-scan-published-images.yml
+++ b/.github/workflows/trivy-scan-published-images.yml
@@ -59,6 +59,7 @@ jobs:
       upload_sarif: false
       generate_sbom: true
       vex_enabled: ${{ contains(matrix.image, 'liquibase-secure') }}
+      dispatch_new_cves: ${{ contains(matrix.image, 'liquibase-secure') }}
       build_logic_ref: main
     secrets: inherit
 
@@ -164,6 +165,14 @@ jobs:
             IMAGE_NAME=$(echo "$EXPECTED_MATRIX" | jq -r ".include[$idx].image")
             IMAGE_TAG=$(echo "$EXPECTED_MATRIX" | jq -r ".include[$idx].tag")
             IMAGE_OR_VERSION="${IMAGE_NAME}:${IMAGE_TAG}"
+
+            # Only dispatch CVEs for liquibase-secure images. Community/alpine
+            # OSS findings are tracked in their own repos and must not flood
+            # investigate-cve.lock.yml in liquibase-pro.
+            if [[ "$IMAGE_NAME" != *liquibase-secure* ]]; then
+              echo "- **${IMAGE_OR_VERSION}**: skipped CVE dispatch (non-secure image)" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
 
             # Reconstruct artifact directory name (same convention as the reusable workflow)
             SAFE_NAME=$(echo "$IMAGE_NAME" | tr '/' '-')

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -47,7 +47,7 @@ jobs:
       suffix: ""
       vex_enabled: false
       upload_sarif: true
-      dispatch_new_cves: true
+      dispatch_new_cves: false
       scout_enabled: true
       build_logic_ref: main
     secrets: inherit
@@ -64,7 +64,7 @@ jobs:
       suffix: "-alpine"
       vex_enabled: false
       upload_sarif: true
-      dispatch_new_cves: true
+      dispatch_new_cves: false
       scout_enabled: true
       build_logic_ref: main
     secrets: inherit


### PR DESCRIPTION
## Summary

`dispatch_new_cves` on `liquibase/build-logic`'s reusable scan workflows triggers `investigate-cve.lock.yml` in `liquibase-pro`. That investigation pipeline is for the commercial `liquibase-secure` docker images — community and alpine OSS findings are tracked separately and should not be funneled there.

This PR scopes dispatch to secure images only across the three scan workflows in this repo.

- `.github/workflows/trivy.yml` — `scan-community` and `scan-alpine` set `dispatch_new_cves: false`. `scan-secure` keeps `true`.
- `.github/workflows/build-qa-docker.yml` — explicit `dispatch_new_cves: false` on `vuln-scan-community` / `vuln-scan-alpine`, explicit `true` on `vuln-scan-secure`. No behavior change today (default is currently `true`), but this stays correct after the upcoming build-logic default flip.
- `.github/workflows/trivy-scan-published-images.yml`:
  - matrix call: `dispatch_new_cves: ${{ contains(matrix.image, 'liquibase-secure') }}` (mirrors the existing `vex_enabled` pattern).
  - hand-rolled dispatch loop in `persist-results`: skip entries where `IMAGE_NAME` does not contain `liquibase-secure`.

Companion PRs:
- liquibase/liquibase-pro: explicit `dispatch_new_cves: true` on the legitimate secure callers
- liquibase/liquibase: `dispatch_new_cves: false` on community/alpine
- liquibase/build-logic: flip the default to `false`

## Test plan

- [ ] Next push or scheduled `Vulnerability Scanning` run dispatches CVEs only for `liquibase-secure`
- [ ] `Build QA Docker` continues to fail on HIGH/CRITICAL findings; only the secure job dispatches
- [ ] `Published Images Vulnerability Scanning` step summary shows "skipped CVE dispatch (non-secure image)" entries for community/alpine matrix tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)