### PR TITLE
TECHOPS-427: bump LPM_VERSION 0.3.3 → 0.3.4 to clear 5 Go stdlib HIGH CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://package.liquibase.
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
     
-ARG LPM_VERSION=0.3.3
-ARG LPM_SHA256=07756491e640be2d7eb9a24a9342e77c13829be1ce3658b00eca4a38fee1ef4b
-ARG LPM_SHA256_ARM=68a8f9bad54ed81861fc2aa2297194cc8ffd9d57c8ceb8fa98beb207e5df9b96
+ARG LPM_VERSION=0.3.4
+ARG LPM_SHA256=b57165a49951e359e782e6f92777ca4b5d152f711a627f1b8dc287dbf661a064
+ARG LPM_SHA256_ARM=6370065118cf306a4b0d0518989c1ae738e600d55f03ceb4f4e005a7080d03aa
     
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Container Image"

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -27,9 +27,9 @@ RUN set -x && \
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
     
-ARG LPM_VERSION=0.3.3
-ARG LPM_SHA256=07756491e640be2d7eb9a24a9342e77c13829be1ce3658b00eca4a38fee1ef4b
-ARG LPM_SHA256_ARM=68a8f9bad54ed81861fc2aa2297194cc8ffd9d57c8ceb8fa98beb207e5df9b96
+ARG LPM_VERSION=0.3.4
+ARG LPM_SHA256=b57165a49951e359e782e6f92777ca4b5d152f711a627f1b8dc287dbf661a064
+ARG LPM_SHA256_ARM=6370065118cf306a4b0d0518989c1ae738e600d55f03ceb4f4e005a7080d03aa
 
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Container Image (Alpine)"

--- a/DockerfileSecure
+++ b/DockerfileSecure
@@ -32,9 +32,9 @@ RUN wget -q -O liquibase-secure-${LIQUIBASE_SECURE_VERSION}.tar.gz "https://repo
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
     
-ARG LPM_VERSION=0.3.3
-ARG LPM_SHA256=07756491e640be2d7eb9a24a9342e77c13829be1ce3658b00eca4a38fee1ef4b
-ARG LPM_SHA256_ARM=68a8f9bad54ed81861fc2aa2297194cc8ffd9d57c8ceb8fa98beb207e5df9b96
+ARG LPM_VERSION=0.3.4
+ARG LPM_SHA256=b57165a49951e359e782e6f92777ca4b5d152f711a627f1b8dc287dbf661a064
+ARG LPM_SHA256_ARM=6370065118cf306a4b0d0518989c1ae738e600d55f03ceb4f4e005a7080d03aa
 
 # Download and Install lpm
 RUN apt-get update && \


### PR DESCRIPTION
## Summary

Bumps `LPM_VERSION` from `0.3.3` to `0.3.4` (and the corresponding SHA256/SHA256_ARM checksums) in all three Dockerfiles to pick up the Go 1.25.10 stdlib patches.

QA vulnerability scans on the docker images (most recent: [liquibase/docker run 25763704364](https://github.com/liquibase/docker/actions/runs/25763704364)) flagged 5 HIGH-severity Go stdlib CVEs in the bundled lpm binary. All are fixed in Go 1.25.10 / 1.26.3:

| CVE | Issue |
|---|---|
| CVE-2026-33811 | cgo DNS LookupCNAME |
| CVE-2026-33814 | HTTP/2 SETTINGS frames |
| CVE-2026-39820 | mail ParseAddress / ParseAddressList |
| CVE-2026-39836 | Dial / LookupPort NUL byte panic |
| CVE-2026-42499 | consumePhrase DoS |

[liquibase-package-manager#619](https://github.com/liquibase/liquibase-package-manager/pull/619) bumped the toolchain to Go 1.25.10 on main, and [v0.3.4](https://github.com/liquibase/liquibase-package-manager/releases/tag/v0.3.4) (released 2026-05-12 21:59Z) is the first tag that picks it up. v0.3.3 was built with Go 1.25.9 and is the version currently baked into all three of our images.

## Checksum provenance

Pulled directly from the [v0.3.4 `checksums.txt`](https://github.com/liquibase/liquibase-package-manager/releases/download/v0.3.4/checksums.txt) asset:

```
b57165a49951e359e782e6f92777ca4b5d152f711a627f1b8dc287dbf661a064  lpm-0.3.4-linux.zip
6370065118cf306a4b0d0518989c1ae738e600d55f03ceb4f4e005a7080d03aa  lpm-0.3.4-linux-arm64.zip
```

## Test plan

- [ ] Trigger `build-qa-docker.yml` with `buildTargets="All (Community + Alpine + Secure)"` after merge and confirm the three vulnerability-scan jobs no longer flag CVE-2026-33811/33814/39820/39836/42499.
- [ ] Verify `lpm --version` reports `0.3.4` from a built image.
- [ ] Confirm both amd64 and arm64 SHA256 checks pass (the build will exit non-zero if either checksum mismatches).

## Notes

The CVE-2022-0839 finding on `org.liquibase:liquibase-core` (the other scan failure) is a separate false-positive on SNAPSHOT version labels and is tracked separately — not addressed here.