### PR TITLE
docs(readme): split cosign verify for v5.2.0 pipeline cutover

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,11 +247,11 @@ Liquibase Secure images include supply chain security features for compliance wi
 
 ### Verify Image Signature
 
-Liquibase Secure images are signed using [Cosign](https://docs.sigstore.dev/cosign/overview/) with keyless signing via GitHub OIDC. The signing pipeline moved from `liquibase/docker` to `liquibase/liquibase-pro` starting with `v5.2.0-SECURE`, so the OIDC identity in each signature depends on the tag.
+Liquibase Secure images are signed using [Cosign](https://docs.sigstore.dev/cosign/overview/) with keyless signing via GitHub OIDC. The signing pipeline moved from `liquibase/docker` to `liquibase/liquibase-pro` starting with `5.2.0`, so the OIDC identity in each signature depends on the tag.
 
 > Install cosign: https://docs.sigstore.dev/cosign/installation/
 
-**Tags `v5.1.1-SECURE` and earlier** (signed by the legacy `liquibase/docker` pipeline):
+**Tags `5.1.1` and earlier** (signed by the legacy `liquibase/docker` pipeline):
 
 ```bash
 cosign verify liquibase/liquibase-secure:<tag> \
@@ -259,7 +259,7 @@ cosign verify liquibase/liquibase-secure:<tag> \
   --certificate-identity-regexp="https://github.com/liquibase/docker/.*"
 ```
 
-**Tags `v5.2.0-SECURE` and later** (signed by the new `liquibase/liquibase-pro` pipeline):
+**Tags `5.2.0` and later** (signed by the new `liquibase/liquibase-pro` pipeline):
 
 ```bash
 cosign verify liquibase/liquibase-secure:<tag> \

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Liquibase Secure images include supply chain security features for compliance wi
 
 ### Verify Image Signature
 
-Liquibase Secure images are signed using [Cosign](https://docs.sigstore.dev/cosign/overview/) with keyless signing via GitHub OIDC. The signing pipeline moved from `liquibase/docker` to `liquibase/liquibase-pro` starting with `5.2.0`, so the OIDC identity in each signature depends on the tag.
+Liquibase Secure images are signed using [Cosign](https://docs.sigstore.dev/cosign/overview/) with keyless signing via GitHub OIDC. The signing pipeline moved from the public repo `liquibase/docker` to a private internal repository starting with `5.2.0`, so the OIDC identity in each signature depends on the tag.
 
 > Install cosign: https://docs.sigstore.dev/cosign/installation/
 
@@ -259,12 +259,12 @@ cosign verify liquibase/liquibase-secure:<tag> \
   --certificate-identity-regexp="https://github.com/liquibase/docker/.*"
 ```
 
-**Tags `5.2.0` and later** (signed by the new `liquibase/liquibase-pro` pipeline):
+**Tags `5.2.0` and later** (signed by the new private internal pipeline):
 
 ```bash
 cosign verify liquibase/liquibase-secure:<tag> \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp="https://github.com/liquibase/liquibase-pro/.*"
+  --certificate-identity-regexp="https://github.com/liquibase/.*"
 ```
 
 ### View SBOM (Software Bill of Materials)

--- a/README.md
+++ b/README.md
@@ -247,13 +247,24 @@ Liquibase Secure images include supply chain security features for compliance wi
 
 ### Verify Image Signature
 
-Liquibase Secure images are signed using [Cosign](https://docs.sigstore.dev/cosign/overview/) with keyless signing via GitHub OIDC. To verify a signature:
+Liquibase Secure images are signed using [Cosign](https://docs.sigstore.dev/cosign/overview/) with keyless signing via GitHub OIDC. The signing pipeline moved from `liquibase/docker` to `liquibase/liquibase-pro` starting with `v5.2.0-SECURE`, so the OIDC identity in each signature depends on the tag.
+
+> Install cosign: https://docs.sigstore.dev/cosign/installation/
+
+**Tags `v5.1.1-SECURE` and earlier** (signed by the legacy `liquibase/docker` pipeline):
 
 ```bash
-# Install cosign: https://docs.sigstore.dev/cosign/installation/
-cosign verify liquibase/liquibase-secure:latest \
+cosign verify liquibase/liquibase-secure:<tag> \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
   --certificate-identity-regexp="https://github.com/liquibase/docker/.*"
+```
+
+**Tags `v5.2.0-SECURE` and later** (signed by the new `liquibase/liquibase-pro` pipeline):
+
+```bash
+cosign verify liquibase/liquibase-secure:<tag> \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp="https://github.com/liquibase/liquibase-pro/.*"
 ```
 
 ### View SBOM (Software Bill of Materials)


### PR DESCRIPTION
## Problem

Secure image `cosign verify` will break for any tag built from the new pipeline. The README ships a single verify command tied to the legacy `liquibase/docker` OIDC identity, so `cosign verify` returns `no matching signatures` for the first new-pipeline tag onward.

## What changed

README now documents two verify stanzas — one for `5.1.1` and earlier (legacy `liquibase/docker`), one for `5.2.0` and later (new `liquibase/liquibase-pro`). Boundaries use the actual Docker image tags (`liquibase/liquibase-secure:<tag>`), which carry no `-SECURE` suffix.

## Result

Customers can verify any Secure image tag, before and after the pipeline cutover. Unblocks the full deprecation of `liquibase/docker` ([TECHOPS-366](https://datical.atlassian.net/browse/TECHOPS-366)).

## Context

- Cutover tag confirmed by @jnewton03 on [TECHOPS-366 comment](https://datical.atlassian.net/browse/TECHOPS-366?focusedCommentId=200653): _"We can use 5.2 as the cutover point."_
- The `-SECURE` suffix only ever existed on git/release tags, never on the `liquibase/liquibase-secure` Docker image tags (verified on Docker Hub: `5.0.0` … `5.1.1`, `latest`).
- Last legacy Secure image tag: `5.1.1`. First new-pipeline image tag: `5.2.0` (signed by workflows in `liquibase/liquibase-pro` post TECHOPS-319; `docker-release.yml` sets `suffix: ""`).

## Test plan

- [ ] Render README on GitHub — both code blocks display cleanly under separate bold labels
- [ ] Once `5.2.0` ships, smoke-test both verify commands against representative tags (`5.1.1` with the legacy stanza, `5.2.0` with the new stanza)

[TECHOPS-366]: https://datical.atlassian.net/browse/TECHOPS-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ