### PR TITLE
TECHOPS-366: Deprecate liquibase/docker repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🟢 Liquibase Community Docker image issues
+    url: https://github.com/liquibase/liquibase/issues/new/choose
+    about: This repository is deprecated. File Community Docker image issues and PRs in liquibase/liquibase (see the docker/ directory).
+  - name: 🔒 Liquibase Secure Docker image support
+    url: https://www.liquibase.com/contact-us
+    about: The liquibase/liquibase-secure image is maintained internally. Contact Liquibase Support for Secure Docker image issues.
+  - name: 📦 Docker Hub images (unchanged)
+    url: https://hub.docker.com/r/liquibase/liquibase
+    about: Docker Hub images liquibase/liquibase and liquibase/liquibase-secure are unaffected by this deprecation.

--- a/README-secure.md
+++ b/README-secure.md
@@ -1,5 +1,16 @@
 # Official Liquibase-Secure Docker Images formerly called Liquibase-Pro
 
+> # ⚠️ This repository is DEPRECATED
+>
+> **`liquibase/docker` is no longer the source for the Liquibase Secure Docker image.** The `liquibase/liquibase-secure` image is now built and maintained internally by Liquibase.
+>
+> - **Issues / requests for the Secure image:** [Contact Liquibase Support](https://www.liquibase.com/contact-us)
+> - **Community Docker image:** see [`liquibase/liquibase`](https://github.com/liquibase/liquibase/tree/main/docker)
+>
+> **Docker Hub is unaffected** — continue pulling `liquibase/liquibase-secure` as before. Existing tags, image history, and signatures remain valid.
+>
+> ---
+
 **Liquibase Secure** is the enterprise edition of Liquibase that provides advanced database DevOps capabilities for teams requiring enhanced security, performance, and governance features.
 
 ## ⚠️ License Requirements

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # Official Liquibase Docker Images
 
+> # ⚠️ This repository is DEPRECATED
+>
+> **`liquibase/docker` is no longer the source for Liquibase Docker images.** As part of the Liquibase 5.0 split between Community and Secure editions, the Dockerfiles have moved to their respective product repositories.
+>
+> | Edition | New source for the Dockerfile | Where to file issues / PRs |
+> | --- | --- | --- |
+> | **Community** — `liquibase/liquibase` | [`liquibase/liquibase`](https://github.com/liquibase/liquibase) (see the [`docker/`](https://github.com/liquibase/liquibase/tree/main/docker) directory) | [liquibase/liquibase issues](https://github.com/liquibase/liquibase/issues) |
+> | **Secure** — `liquibase/liquibase-secure` | Maintained internally by Liquibase | [Contact Liquibase Support](https://www.liquibase.com/contact-us) |
+>
+> **Docker Hub images are unaffected.** Continue pulling `liquibase/liquibase` and `liquibase/liquibase-secure` as before — existing tags, image history, and signatures remain valid.
+>
+> This repository is preserved in read-only / archived state so historical issues, PRs, releases, and git tags (`v{version}`, `v{version}-SECURE`) stay discoverable.
+>
+> ---
+
 ## 🚨 Important: Liquibase 5.0 Changes 🚨
 
 ### Liquibase Community vs Liquibase Secure


### PR DESCRIPTION
## Summary

Final story under DAT-22522. The Community (DAT-22523) and Secure (DAT-22524) Dockerfile migrations have landed, so this PR begins deprecating `liquibase/docker`.

This PR covers the **repo-content** portion of TECHOPS-366:

- ✅ `README.md` — prominent **DEPRECATED** banner redirecting Community users to [`liquibase/liquibase`](https://github.com/liquibase/liquibase/tree/main/docker) and Secure users to support
- ✅ `README-secure.md` — DEPRECATED banner redirecting Secure users to support
- ✅ `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues and redirects new issues to the product repo / support

Docker Hub images (`liquibase/liquibase`, `liquibase/liquibase-secure`), tags, history, and signatures are **unaffected**.

## ⚠️ Merge ordering note

On merge, `publish-oss-readme.yml` and `publish-liquibase-secure-readme.yml` will push these updated READMEs to Docker Hub — this satisfies AC "Docker Hub README updated on both images". **Keep these workflows until that publish has run.** Workflow removal + repo archive happen as follow-up steps (see ticket).

## Remaining (outside this PR — tracked on TECHOPS-366)

- [ ] GitHub repo description → `[DEPRECATED] ...`
- [ ] Triage / close open issues + PRs with redirect comment
- [ ] Remove/disable remaining workflows (after Docker Hub publish)
- [ ] Update customer docs (docs.liquibase.com)
- [ ] Slack / GitHub Discussion announcement
- [ ] Archive repo (read-only) — **LAST**

🤖 Generated with [Claude Code](https://claude.com/claude-code)